### PR TITLE
feat(ci): :construction_worker: Add semantic-release to CI workflow

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -53,6 +53,7 @@ jobs:
       checks: write
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.12"

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           # Fetch the full history
           # this is required for the hawkeye license header checker to be able to
-          # determine teh modified date of the files.
+          # determine the modified date of the files.
           fetch-depth: 0
       - uses: actions/setup-python@v4
       - uses: pre-commit/action@v3.0.1
@@ -53,18 +53,6 @@ jobs:
       checks: write
     runs-on: ubuntu-latest
     steps:
-      - name: Get App Token for Coverage App
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.COVERAGE_APP_APPID }}
-          private-key: ${{ secrets.COVERAGE_APP_SECRET }}
-
-      - name: Checkout with App Token
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
-          token: ${{ steps.app-token.outputs.token }}
       - uses: actions/setup-python@v4
         with:
           python-version: "3.12"
@@ -77,14 +65,6 @@ jobs:
         with:
           pytest-xml-coverage-path: ./coverage.xml
           junitxml-path: junit/test-results.xml
-
-      - name: Upload pytest test results
-        uses: actions/upload-artifact@v4
-        with:
-          name: pytest-results
-          path: junit/test-results.xml
-        # Use always() to always run this step to publish test results when there are test failures
-        if: ${{ always() }}
       - name: Update Gist for Coverage Badge in README.md
         uses: schneegans/dynamic-badges-action@v1.7.0
         if: ${{ github.ref_name == github.event.repository.default_branch }}
@@ -102,3 +82,33 @@ jobs:
       #   with:
       #     message: Update coverage on Readme
       #     github_token: ${{ steps.app-token.outputs.token }}
+
+  version-manage:
+    if: ${{ github.ref_name == github.event.repository.default_branch }}
+    needs: [pre-commit, tests]
+    concurrency: release
+    permissions:
+      pull-requests: write
+      contents: write
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get App Token for Coverage App
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          # Poorly named; this is a token with contents read/write for having CI make changes to the repo.
+          # TODO: update this later.
+          app-id: ${{ vars.COVERAGE_APP_APPID }}
+          private-key: ${{ secrets.COVERAGE_APP_SECRET }}
+      - name: Checkout with App Token
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Python Semantic Release
+        # Adjust tag with desired version if applicable. Version shorthand
+        # is NOT available, e.g. vX or vX.X will not work.
+        uses: python-semantic-release/python-semantic-release@v9.8.8
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,3 +118,7 @@ select = [
 # Measure branch coverage in addition to statement coverage.
 branch = true
 # source_pkgs = ["digital_ocean_dynamic_dns"]
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+version_variables = ["src/digital_ocean_dynamic_dns/__init__.py:__version__"]


### PR DESCRIPTION
Should enable semantic-release to be run on the main branch from now on