### PR TITLE
chore: update copier-everything template to v1.10.1

### DIFF
--- a/.config/rumdl.toml
+++ b/.config/rumdl.toml
@@ -5,7 +5,10 @@
 
 [global]
 # Don't enforce a hard line length on prose.
-disable = ["MD013"]
+# MD033 (no inline HTML) is off too: the MkDocs docs-site design deliberately relies on raw
+# HTML passing through Markdown unmodified — castify's <figure class="cast"> embeds and a
+# per-plugin <span data-version="..."> version-badge convention both need it.
+disable = ["MD013", "MD033"]
 # release-please owns CHANGELOG.md and regenerates it with multiple consecutive blank
 # lines (MD012) on every release PR; exclude generated changelogs from the prose linter.
 exclude = ["LICENSE", "LICENSES/**", "**/CHANGELOG.md"]
@@ -13,3 +16,14 @@ exclude = ["LICENSE", "LICENSES/**", "**/CHANGELOG.md"]
 [MD046]
 # Always use fenced code blocks (```lang), never 4-space-indented.
 style = "fenced"
+
+[per-file-ignores]
+# MD033 (no inline HTML): castify's <figure class="cast"> embeds and similar raw-HTML
+# docs-site conventions need this even though MD033 is already off globally above — this
+# scopes it to just the docs tree if the global disable is ever narrowed later.
+# MD046 (fenced over indented): pymdownx.tabbed's content nesting under `=== "tab"`
+# requires 4-space indentation, the same convention as a list continuation — rumdl's
+# parser mistakes that indentation ahead of an already-fenced block for a raw indented
+# code block, then "fixes" it by wrapping the tab's prose in stray fences too, destroying
+# the tab structure (see nivintw/copier-everything#178).
+"docs/*.md" = ["MD033", "MD046"]

--- a/.config/typos.toml
+++ b/.config/typos.toml
@@ -5,9 +5,10 @@
 # typos is treated as CHECK-ONLY (the hook drops --write-changes).
 
 [files]
-# CHANGELOG.md is generated from commit history (release-please): it carries commit SHAs and
-# verbatim historical commit messages that aren't authored prose to spellcheck. rumdl already
-# excludes it; mirror that here.
+# release-please regenerates CHANGELOG.md from commit SHAs, PR/issue titles it doesn't
+# control — a commit SHA's hex prefix colliding with a dictionary word (e.g. "caf" in
+# "21caf01" reading as "calf") would otherwise block release-please's own auto-merge on an
+# unrelated, unfixable false positive.
 extend-exclude = ["CHANGELOG.md"]
 
 [default]

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY.
-_commit: v1.9.0
+_commit: v1.10.1
 _src_path: gh:nivintw/copier-everything
 author_email: tyler@nivin.tech
 author_name: Tyler Nivin

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,4 +17,4 @@ SPDX-License-Identifier: MIT
 
 <!-- How did you test it? -->
 
-- [ ] The quality gate passes (`uvx prek run --all-files`)
+- [ ] The quality gate passes (`uvx prek@0.4.8 run --all-files`)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,10 +17,10 @@
       "groupName": "ruff"
     },
     {
-      "description": "Only re-run the checksum refresh when one of the 5 tools the customManager below discovers via its # renovate: annotations actually changed — so an unrelated update (a ruff-pre-commit bump, an actions/checkout digest bump, etc.) doesn't also shell out to 5 external release hosts.",
+      "description": "Only re-run the checksum refresh when one of the 5 tools the customManager below discovers via its # renovate: annotations actually changed — so an unrelated update (a ruff-pre-commit bump, an actions/checkout digest bump, etc.) doesn't also shell out to 5 external release hosts. BASE_REF is computed inline (merge-base against the default branch) rather than relying on the runner to export it, so the script's supply-chain tamper gate (refuse a same-version/different-hash re-pin) is always active on this automated path — and the command fails loudly if that computation itself fails, rather than letting a silently-empty BASE_REF degrade back to the gate being off.",
       "matchPackageNames": ["aquasecurity/trivy", "google/osv-scanner", "korandoru/hawkeye", "tamasfe/taplo", "yannh/kubeconform"],
       "postUpgradeTasks": {
-        "commands": ["scripts/refresh-binary-checksums.sh"],
+        "commands": ["BASE_REF=\"$(git merge-base HEAD origin/HEAD)\" || { echo 'ERROR: could not compute BASE_REF via git merge-base — refusing to run with the tamper gate silently disabled' >&2; exit 1; }; export BASE_REF; scripts/refresh-binary-checksums.sh"],
         "fileFilters": [".github/workflows/**"],
         "executionMode": "branch"
       }
@@ -34,6 +34,21 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+\\w+: \"(?<currentValue>[^\"]+)\""
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "prek is pinned identically in CI and every doc that tells a contributor what to run locally, so local runs always match CI. No `# renovate:` annotation needed — the visible `uvx prek@X.Y.Z` command text itself is the tracked value, matched directly wherever it appears; matching depName/datasource across files means Renovate bumps every occurrence together in one PR.",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/.+\\.ya?ml$/",
+        "/^AGENTS\\.md$/",
+        "/^README\\.md$/",
+        "/^CONTRIBUTING\\.md$/",
+        "/^\\.github/PULL_REQUEST_TEMPLATE\\.md$/",
+        "/^\\.pre-commit-config\\.yaml$/"
+      ],
+      "matchStrings": ["uvx prek@(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"],
+      "datasourceTemplate": "pypi",
+      "depNameTemplate": "prek"
     }
   ]
 }

--- a/.github/workflows/approve-bot-prs.yml
+++ b/.github/workflows/approve-bot-prs.yml
@@ -33,10 +33,15 @@
 # approvals stop appearing, check the variable against the App slug first.
 #
 # DELIBERATELY INERT: this workflow holds no secrets and runs no third-party actions.
-# pull_request events execute the PR's own merge-ref workflow definition, so keeping
-# credentials and bump-able `uses:` pins out of this file means a bot PR (e.g. a Renovate
-# action-digest bump) can never make it run new, unreviewed code holding anything
-# sensitive.
+# Triggered via pull_request_target (not pull_request): the latter executes the PR's OWN
+# branch's copy of this workflow file, so a same-repo PR editing the TRUST ANCHOR condition
+# above would have its own weakened version run for its own approval — auto-approving
+# itself via the github-actions[bot] identity, which sidesteps GitHub's "can't approve your
+# own PR" rule. pull_request_target anchors the workflow DEFINITION to the base branch
+# regardless of what the PR's branch contains, closing that gap. This is the one case where
+# pull_request_target is safe despite the usual warning about it (checkout + secrets on
+# untrusted code): there is no checkout and no secret here, only a same-repo/same-actor
+# trust check and an approval call — see zizmor's dangerous-triggers suppression below.
 #
 # Re-approves on synchronize: paired with required approvals, rulesets usually dismiss
 # stale reviews on push, so every Renovate rebase discards the previous approval and it
@@ -44,8 +49,12 @@
 
 name: approve-bot-prs
 
-on:
-  pull_request:
+# zizmor's ignore comment must be a trailing comment on `on:` itself (a preceding standalone
+# comment block, however close, is not honored) — pull_request_target is safe here: no
+# checkout, no secrets, just the same-repo/same-actor trust check and an approval call (see
+# DELIBERATELY INERT above).
+on: # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 # Approving needs pull-requests:write; every other scope stays none. There is no checkout.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,15 +11,12 @@
 # has no release process for this workflow, so Renovate tracks and bumps the digest instead,
 # same as it does for every other `uses:` pin in this file (see main.yml/docs on Renovate's
 # GitHub Actions digest-pinning).
-#
-# MANUAL TRIGGER ONLY, for now: repo-management's `.github/workflows/docs.yml` doesn't exist
-# yet (tracked at nivintw/repo-management#86, part of the same fleet-wide rollout as the
-# design spec referenced above) — a `push` trigger here would fire on every new project's
-# first commit touching docs/**/mkdocs.yml and fail outright (a broken `uses:` target fails
-# the run, it doesn't no-op). Add the `push` trigger back once #86 ships.
 name: docs
 
 on:
+  push:
+    branches: [main]
+    paths: ['docs/**', 'mkdocs.yml']
   workflow_dispatch:
 
 concurrency:
@@ -32,4 +29,4 @@ jobs:
       contents: read
       pages: write
       id-token: write
-    uses: nivintw/repo-management/.github/workflows/docs.yml@22812b52c1c212b57ddef29da6e18e96afce03c7 # main
+    uses: nivintw/repo-management/.github/workflows/docs.yml@864420032528f0d7339fe07a44630b620f16d88b # main

--- a/.github/workflows/label-hygiene.yml
+++ b/.github/workflows/label-hygiene.yml
@@ -15,7 +15,10 @@
 # repo that never adopted the taxonomy (this template does not provision these labels) is a
 # clean no-op — nothing gates the file, and there's nothing to error on. type:* / priority:*
 # are left intact as a historical record. Reopen is deliberately left to manual triage: we
-# act on `closed` only, so a reopened issue isn't silently shoved back to a status.
+# act on `closed` only, so a reopened issue isn't silently shoved back to a status — the
+# step itself also re-checks the issue is STILL closed before stripping (see below), so a
+# reopen racing between the `closed` event and this run executing doesn't strip a live
+# issue's progression label.
 
 name: label-hygiene
 
@@ -60,16 +63,26 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # Fetch + filter to the progression set in ONE command substitution, so a failed
-          # API call (network, secondary-rate-limit, read-only token) aborts the job under
-          # `set -e`. Do NOT read this via `mapfile < <(gh ...)`: a command's exit status
-          # inside `< <(...)` process substitution is invisible to set -e/pipefail, so a gh
-          # failure would be masked as "no labels" and silently skip the cleanup — the exact
-          # opposite of this workflow's purpose. Exact-match (== / or) needs no regex engine.
-          matched="$(
-            gh issue view "$ISSUE" --repo "$REPO" --json labels \
-              --jq '.labels[].name | select(. == "status:triage" or . == "status:ready" or . == "status:in-progress" or . == "status:in-review" or . == "status:blocked")'
-          )"
+          # Fetch state + labels in ONE command substitution, so a failed API call (network,
+          # secondary-rate-limit, read-only token) aborts the job under `set -e`. Do NOT read
+          # this via `mapfile < <(gh ...)`: a command's exit status inside `< <(...)` process
+          # substitution is invisible to set -e/pipefail, so a gh failure would be masked as
+          # "no labels" and silently skip the cleanup — the exact opposite of this workflow's
+          # purpose. The `jq` calls below run against this already-fetched string, not a new
+          # `gh` call, so they carry no equivalent risk.
+          issue_json="$(gh issue view "$ISSUE" --repo "$REPO" --json state,labels)"
+          # Re-check the issue is STILL closed: the `closed` event scheduled this run, but a
+          # reopen between then and now doesn't re-trigger or cancel it (reopening emits no
+          # `closed` event, so the concurrency group above never sees a second run to race
+          # against). Stripping an active issue's progression label on stale trigger data
+          # would be exactly the fiction this workflow exists to prevent.
+          state="$(jq -r '.state' <<<"$issue_json")"
+          if [ "$state" != "CLOSED" ]; then
+            echo "Issue #$ISSUE is no longer closed (state: $state) — a reopen raced this run; skipping."
+            exit 0
+          fi
+          # Exact-match (== / or) needs no regex engine.
+          matched="$(jq -r '.labels[].name | select(. == "status:triage" or . == "status:ready" or . == "status:in-progress" or . == "status:in-review" or . == "status:blocked")' <<<"$issue_json")"
           if [ -z "$matched" ]; then
             echo "No status:* progression labels on issue #$ISSUE — nothing to do."
             exit 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,3 +132,74 @@ jobs:
             exit 0
           fi
           gh pr merge "$num" --auto --rebase
+
+      # This template's own release-please-config.json.jinja always scaffolds a single
+      # package, so this never fires against a freshly-generated repo as-is — it guards the
+      # moment a consumer extends that config to 2+ packages by hand (release-please
+      # supports it; the config is a plain file a consumer can and does edit), which is
+      # exactly the real-world incident that motivated this fix. Once that happens: each
+      # package's Release PR bumps its own line in the SHARED manifest, so the first to
+      # auto-merge above changes main and every other Release PR's branch now textually
+      # conflicts with main on that shared file (mergeStateStatus DIRTY) and can never
+      # auto-merge. release-please doesn't refresh a stale branch whose generated content is
+      # unchanged — it compares the changes it wants, not branch mergeability — so a DIRTY
+      # Release PR never self-heals on its own. Close it instead: closing is release-please's
+      # documented regeneration path, so the next run that reaches this component recreates
+      # its Release PR from a fresh main (conflict-free), and the auto-merge step above
+      # re-arms it. Identified via the same CI_APP_SLUG trust anchor as approve-bot-prs.yml
+      # (author login == <slug>[bot]) plus release-please's own `autorelease: pending` label
+      # — both more stable than the tool's undocumented branch-naming — and fails closed
+      # (no-op) if the variable isn't set, same as that workflow. The label check is literal
+      # equality against DIRTY (not "!= CLEAN"): mergeStateStatus is transiently UNKNOWN right
+      # after a push, so a just-orphaned PR simply isn't caught this run and converges on a
+      # later one instead of being misclassified.
+      - name: Close any stranded (DIRTY) Release PRs so release-please regenerates them
+        if: vars.CI_APP_SLUG != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          CI_APP_SLUG: ${{ vars.CI_APP_SLUG }}
+        run: |
+          set -euo pipefail
+          # `gh pr list --jq` only accepts a single filter expression (no `--arg` passthrough,
+          # unlike standalone jq) — piping through jq directly instead. Assigning the listing
+          # to a variable (rather than `mapfile < <(...)`, which runs the producer in a process
+          # substitution whose exit status `set -e` can't see) makes a `gh pr list` failure
+          # (auth, API 5xx) abort the step loudly instead of silently reading as "none found".
+          # --limit raised well past gh's 30-item default so a busier repo's stranded PR can't
+          # fall off the first page.
+          prs_json="$(gh pr list --state open --limit 100 \
+            --json number,author,labels,mergeStateStatus)"
+          # Same reasoning as above: a plain assignment (not `mapfile < <(...)`) so a jq
+          # failure trips `set -e` too, instead of silently reading as "none found". An empty
+          # filter result is a legitimate zero-matches outcome, not a failure — `mapfile` from
+          # an empty string yields a one-element array holding "", so that case is normalized
+          # back to a true zero-length array below.
+          stranded_str="$(printf '%s' "$prs_json" | jq --arg app "${CI_APP_SLUG}[bot]" \
+            '.[] | select(.author.login == $app and (.labels[]?.name == "autorelease: pending") and .mergeStateStatus == "DIRTY") | .number')"
+          stranded=()
+          if [ -n "$stranded_str" ]; then
+            mapfile -t stranded <<<"$stranded_str"
+          fi
+          if [ "${#stranded[@]}" -eq 0 ]; then
+            echo "No stranded Release PRs found."
+            exit 0
+          fi
+          for num in "${stranded[@]}"; do
+            echo "Closing stranded Release PR #${num} (DIRTY against current main)."
+            # Tolerate ONLY the expected race (someone/something else already closed or
+            # merged it between the list above and this close) so one benign race doesn't
+            # abort the rest of the batch; every other failure still reddens the job.
+            if ! gh pr close "$num" --comment "Closing — this Release PR's manifest edit now conflicts with main after another same-cycle Release PR merged first. release-please will regenerate this PR from a fresh main next time it runs for this component."; then
+              if ! state="$(gh pr view "$num" --json state --jq '.state')"; then
+                echo "::error::Could not verify state of PR #${num} after the close attempt above failed." >&2
+                exit 1
+              fi
+              if [ "$state" = "CLOSED" ] || [ "$state" = "MERGED" ]; then
+                echo "::notice::PR #${num} was already $(printf '%s' "$state" | tr '[:upper:]' '[:lower:]') before this step could close it — skipping."
+                continue
+              fi
+              echo "::error::Failed to close stranded Release PR #${num} for an unexpected reason." >&2
+              exit 1
+            fi
+          done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,8 @@
 # Publish releases to PyPI, dress-rehearsed through TestPyPI first. release-please
 # (main.yml) cuts the `vX.Y.Z` tag + GitHub Release; this fires on that Release (event
 # `release: published`) and drives: build once → publish to TestPyPI → smoke (assert the
-# release is visible on TestPyPI, then install and import the built wheel) → publish to
+# release is visible on TestPyPI, then install the built wheel and run its console script
+# if it has one, else import the package) → publish to
 # PyPI. The artifact set is built exactly once and passed between jobs, so what lands on
 # PyPI is byte-for-byte the set the smoke test installed from. PyPI uploads are immutable —
 # a broken artifact burns the version number — which is what the rehearsal stage is for.
@@ -153,7 +154,7 @@ jobs:
         with:
           enable-cache: false
 
-      - name: Confirm TestPyPI visibility, then import the built wheel
+      - name: Confirm TestPyPI visibility, then smoke-test the built wheel
         # The index can lag a fresh upload by a few seconds; `-f` turns TestPyPI's
         # pre-visibility 404 into a curl error, so --retry-all-errors polls until it's
         # live — the same retry idiom ci.yml.jinja uses for flaky/eventually-consistent
@@ -168,10 +169,28 @@ jobs:
               "https://test.pypi.org/pypi/digital-ocean-dynamic-dns/${VERSION}/json" \
             || { echo "::error::digital-ocean-dynamic-dns==${VERSION} never appeared on TestPyPI"; exit 1; }
           # --python matches requires-python in pyproject.toml (the runner's system Python
-          # may be older; uv fetches its managed interpreter).
+          # may be older; uv fetches its managed interpreter). Whether this package ships a
+          # console script varies per project and isn't worth its own copier question — the
+          # installed wheel's own entry-point metadata already says so. Run it if present
+          # (exercises the real registered command, not just an importable function — a
+          # broken `[project.scripts]` entry or build-backend misconfiguration would still
+          # pass a bare import); fall back to a plain import otherwise.
           uv run --isolated --no-project --python 3.12 \
             --with dist/*.whl \
-            -- python -c "import digital_ocean_dynamic_dns"
+            -- python - <<'PY'
+          import importlib.metadata as metadata
+          import subprocess
+
+          entry_points = [
+              ep
+              for ep in metadata.entry_points(group="console_scripts")
+              if ep.dist and ep.dist.name == "digital-ocean-dynamic-dns"
+          ]
+          if entry_points:
+              subprocess.run([entry_points[0].name, "--help"], check=True)
+          else:
+              import digital_ocean_dynamic_dns
+          PY
 
   pypi:
     needs: smoke

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 .idea/
 *~
 
+### superpowers:brainstorming local artifacts (mockups/companions, never committed) ###
+.superpowers/
+
 ### Python / uv ###
 __pycache__/
 *.py[cod]
@@ -32,3 +35,6 @@ build/
 
 # dev-kit /ship run progress (ephemeral, per-run)
 .ship/
+
+### MkDocs ###
+site/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@
 
 # Pre-commit hooks, run by prek (https://github.com/j178/prek). Designed to run
 # identically in CI — most hooks self-bootstrap a pinned env.
-#   Run on demand:  uvx prek run --all-files
-#   Install hooks:  uvx prek install
+#   Run on demand:  uvx prek@0.4.8 run --all-files
+#   Install hooks:  uvx prek@0.4.8 install
 
 default_install_hook_types: [pre-commit, commit-msg]
 default_stages: [pre-commit, manual]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,11 +15,13 @@ grows.
 One command runs every lint, format, license, and security check (the same set CI runs):
 
 ```console
-uvx prek run --all-files
+uvx prek@0.4.8 run --all-files
 ```
 
 Run it before you consider a change done; fix what it flags rather than suppressing it. Hooks
-also run automatically on commit once `uvx prek install` has been run.
+also run automatically on commit once `uvx prek@0.4.8 install` has been run. The version is
+pinned to match CI exactly (`ci.yml`'s "Run prek hooks (same as local)" step) — Renovate bumps
+it here and in CI together.
 
 ## Commits
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thanks for contributing!
 ## Workflow
 
 1. Branch off `main` and land changes via a PR (enable branch protection to enforce it).
-2. Run `uv sync` to set up the dev environment, then install the hooks: `uvx prek install`.
+2. Run `uv sync` to set up the dev environment, then install the hooks: `uvx prek@0.4.8 install`.
 3. Make your change. The pre-commit hooks run the full quality gate — the same checks run in CI.
 4. Commit with [Conventional Commits](https://www.conventionalcommits.org), enforced by
    commitizen at commit-msg time. release-please cuts releases from these commits (a
@@ -20,5 +20,5 @@ Thanks for contributing!
 ## Running the quality gate
 
 ```bash
-uvx prek run --all-files
+uvx prek@0.4.8 run --all-files
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,19 +3,52 @@
 
 # MkDocs Material config — the one shared "Terminal Slate" theme reused identically across
 # every copier-everything-descended repo (fleet-wide docs design; see
-# docs/superpowers/specs/2026-07-04-mkdocs-fleet-epic-design.md in the template source for
-# the full rationale). This file only scaffolds the mechanism — real navigation and content
-# are authored per repo by the generate-docs skill, not here.
+# nivintw/repo-management#85 for the full rationale). This file only scaffolds the
+# mechanism — real navigation and content are authored per repo by the generate-docs
+# skill, not here. theme.features/markdown_extensions/edit_uri/the 404 override below are
+# the fleet-general subset nivintw-claude-skills proved out first and folded back upstream
+# (nivintw/copier-everything#178) — repo-specific extras (e.g. content.tabs.link, which
+# only earns its place once a repo actually has tabbed content) stay out of the baseline.
 site_name: "Digital Ocean Dynamic DNS"
 site_description: "Python-based CLI tool for managing dynamic dns with Digital Ocean."
 site_url: "https://nivintw.github.io/ddns/"
 repo_url: "https://github.com/nivintw/ddns"
 repo_name: "nivintw/ddns"
+edit_uri: "edit/main/docs/"
 
 theme:
   name: material
+  # overrides/404.html (scaffolded alongside this file) — Material treats 404.html as a
+  # "static template" rendered straight from the theme, not from a docs/404.md source, so
+  # a docs/404.md would build but its content is silently discarded; custom_dir + a theme
+  # override is the only documented way to customize the page.
+  custom_dir: overrides
   favicon: assets/favicon.svg
   logo: assets/favicon.svg
+  features:
+    # Copy-to-clipboard on every code block.
+    - content.code.copy
+    # Instant navigation (SPA-style: fetches and swaps content instead of a full page
+    # reload) + a slim top progress bar for the fetch. This is what actually cashes in a
+    # document$-based JS hydration pattern (see castify's embedding.md reference) on every
+    # transition, not just the initial load.
+    - navigation.instant
+    - navigation.instant.progress
+    # Keeps the URL hash in sync with the heading scrolled into view, and a "back to top"
+    # button once you've scrolled past the first screen — free wins on any page that runs
+    # long, and cost nothing on the ones that don't.
+    - navigation.tracking
+    - navigation.top
+    - toc.follow
+    # Search-as-you-type suggestions, query-term highlighting on the result page, and a
+    # shareable #search-url — table stakes for a docs site's built-in search.
+    - search.suggest
+    - search.highlight
+    - search.share
+    # A small affordance for a reader who spots something to fix: jump straight to this
+    # page's source on GitHub (wired via edit_uri above) instead of hunting for the file.
+    - content.action.edit
+    - content.tooltips
   palette:
     # No `media:` binding on either entry: the FIRST scheme below is what every new visitor
     # sees regardless of OS preference (dark by design, not just by default-detection) — the
@@ -33,14 +66,64 @@ theme:
         icon: material/brightness-7
         name: Switch to dark mode
 
-# Wired for the vendored asciinema-player assets (see castify's embedding.md reference doc)
-# so a repo only needs to drop the vendored files at these conventional paths under
-# docs/assets/ to embed a `<figure class="cast">` terminal recording — a repo with no casts
-# to embed never references them and is unaffected by the paths not existing yet.
-extra_css:
-  - assets/asciinema-player.css
-extra_javascript:
-  - assets/asciinema-player.min.js
+# Fleet-general baseline only — each entry earns its place with real content it enables,
+# not just because Material supports it (no mermaid custom_fences here; pymdownx.emoji is
+# scoped to Material's own icon set, never a general emoji picker — see below).
+markdown_extensions:
+  # Material's own icon set (nav icons, admonition icons, card-grid layouts) — the
+  # emoji_index/generator pair is Material's documented way to wire :material-*:/
+  # :octicons-*: glyphs, not a general emoji picker.
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  # Callouts (!!! note / !!! tip / ??? details, collapsible) instead of plain blockquotes.
+  - admonition
+  - pymdownx.details
+  # Fenced code blocks that nest cleanly inside an admonition or tab, proper syntax
+  # highlighting (line-anchored so a code line is linkable), and inline code that gets the
+  # same highlighting treatment as a fenced block.
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+  - pymdownx.inlinehilite
+  # Content tabs (e.g. an "Install" section with marketplace vs. local-clone instructions)
+  # and grid-card layouts both need attr_list to attach a class/id to a Markdown block.
+  - pymdownx.tabbed:
+      alternate_style: true
+  - attr_list
+  # Lets Markdown syntax (bold, code spans, links) work *inside* a raw HTML block.
+  - md_in_html
+  - footnotes
+
+# docs/superpowers/** holds dev-only brainstorming specs and plans (the
+# superpowers:brainstorming/writing-plans convention) — shares the docs/ tree with the
+# published site but is never meant to be site content, and generate-docs never touches it.
+# `mkdocs build --strict` fails on any *.md under docs_dir that isn't in nav: below, so
+# exclude it explicitly rather than every repo re-discovering this the hard way.
+#
+# `exclude_docs` is mkdocs' PathSpec option (gitignore-style patterns) — a multiline
+# STRING, not a YAML list. A list renders here as a config error mkdocs never accepted
+# ("Expected a multiline string, but a <class 'list'> was given"), confirmed against the
+# same mkdocs==1.6.1/mkdocs-material==9.7.6 pins the fleet's reusable docs workflow uses;
+# render-matrix.sh's gate never runs `mkdocs build` itself so nothing caught this until a
+# real build was tried (nivintw/copier-everything#157).
+exclude_docs: |
+  superpowers/
+
+# MkDocs 1.5+'s own validation checks, made explicit rather than left to its undocumented
+# defaults — `warn` is what `--strict` (this fleet's `generate-docs` Stage 4 always builds
+# with) promotes to a hard failure, so a broken nav entry, dead link, missing anchor, or
+# non-portable absolute path is caught locally before it's caught live.
+validation:
+  nav:
+    omitted_files: warn
+    not_found: warn
+    absolute_links: warn
+  links:
+    not_found: warn
+    anchors: warn
+    absolute_links: warn
 
 nav:
   - Home: index.md

--- a/overrides/404.html
+++ b/overrides/404.html
@@ -1,0 +1,24 @@
+<!--
+
+    SPDX-FileCopyrightText: © 2023 Tyler Nivin
+    SPDX-License-Identifier: MIT
+
+-->
+
+{% extends "main.html" %}
+
+{# Material registers 404.html as a "static template" rendered straight from the theme,
+   not from a docs/404.md source — a docs/404.md builds but its content is silently
+   discarded (the static-template render overwrites the same output path afterward). This
+   override is the actual, documented mechanism for customizing the page. The copy below
+   is a generic placeholder: the template only scaffolds the mechanism, not per-repo
+   wording — replace it with real copy once the site has real pages to link to. #}
+{% block content %}
+<h1>Page not found</h1>
+
+<p>That page doesn't exist — it may have moved, or the link is out of date.</p>
+
+<p>
+  <a href="{{ base_url }}" class="md-button md-button--primary">Back to the homepage</a>
+</p>
+{% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,11 @@ Repository = "https://github.com/nivintw/ddns"
 Issues = "https://github.com/nivintw/ddns/issues"
 
 [dependency-groups]
-# The ruff floor must support the rendered `target-version = "py312"`: py314 needs ruff>=0.12.
-# Bump this floor when raising python_version past what the current floor supports.
+# One line keeps it green-on-arrival under taplo, which collapses short arrays after render.
+# The ruff floor is fleet-wide, not this repo's target-version specifically: raised to
+# >=0.12 for py314 support (copier-everything#73/v1.3.2), and it works fine against every
+# earlier supported python_version too. Bump it again only if a future python_version needs
+# a newer floor than this one provides.
 # ty is pre-1.0 and evolves quickly, so ">=0.0.1" is a permissive floor, not a meaningful one —
 # Renovate keeps the resolved version current regardless.
 dev = [

--- a/scripts/refresh-binary-checksums.sh
+++ b/scripts/refresh-binary-checksums.sh
@@ -16,10 +16,11 @@
 # Tamper gate (automation): the caller sets BASE_REF=<git ref> to enforce supply-chain
 # safety. A SHA is then only re-pinned when the *_VERSION actually changed vs BASE_REF; a SHA
 # that differs from upstream while the version is UNCHANGED is treated as a tampered/swapped
-# release asset and fails the run — never silently re-pinned. The central self-hosted Renovate
-# runner must export BASE_REF (e.g. origin/<base-branch>) when it runs this as a postUpgradeTask,
-# or the gate is off. Without BASE_REF (a human running it locally after a deliberate bump) it
-# just recomputes every pin.
+# release asset and fails the run — never silently re-pinned. The postUpgradeTask command
+# computes BASE_REF inline via `git merge-base` against the default branch (and fails loudly
+# if that computation itself fails), so the gate is always active on the automated path.
+# Without BASE_REF (a human running it locally after a deliberate bump) it just recomputes
+# every pin.
 #
 # Requirements: bash 4.4+, curl, sha256sum (or shasum), sed, grep, awk, mktemp, head; git when BASE_REF set.
 set -euo pipefail
@@ -107,14 +108,33 @@ cached_sha() { # <TOOL> <version> <outvar>
 
 # Extract the quoted value of an env-var assignment (first occurrence). Empty (exit 0) when absent.
 pinned_value() { # <VAR> <file> -> value or empty
+  # Fail loudly on a bad path instead of masking it as "no pin found": grep's own exit code
+  # conflates "no match" (1 — the intended empty-return case) with "read error" (>=2, e.g. a
+  # missing or unreadable file). The guard below catches a missing file up front; capturing
+  # grep's own exit code (not the head/sed pipeline's, which would swallow it) catches any
+  # other read failure the guard doesn't, e.g. a file that exists but isn't readable.
+  [ -f "$2" ] || {
+    echo "ERROR: pinned_value: no such file: $2" >&2
+    exit 1
+  }
   # Anchored to (whitespace-then-)line-start so a search for TRIVY_VERSION can't match inside
   # a hypothetical OLD_TRIVY_VERSION — a bare \b wouldn't help here since `_` is a word char.
-  grep -oE "^[[:space:]]*$1: \"[^\"]+\"" "$2" 2>/dev/null | head -n1 | sed -E 's/.*"([^"]+)".*/\1/' || true
+  local matched grep_rc
+  matched="$(grep -oE "^[[:space:]]*$1: \"[^\"]+\"" "$2")" && grep_rc=0 || grep_rc=$?
+  if [ "$grep_rc" -gt 1 ]; then
+    echo "ERROR: pinned_value: grep failed reading $2 (exit $grep_rc)" >&2
+    exit 1
+  fi
+  printf '%s\n' "$matched" | head -n1 | sed -E 's/.*"([^"]+)".*/\1/'
 }
 pinned_value_at_base() { # <VAR> <file> <baseref> -> value at base or empty
-  # grep here reads from git show's pipe, not a file arg, so there's no "file not found"
-  # stderr to suppress (unlike pinned_value()'s grep, which does need it).
-  git show "$3:$2" 2>/dev/null | grep -oE "^[[:space:]]*$1: \"[^\"]+\"" | head -n1 | sed -E 's/.*"([^"]+)".*/\1/' || true
+  # A path absent at BASE_REF (introduced since) is the one legitimate empty case here —
+  # check for it explicitly with git cat-file -e, rather than folding it into a blanket
+  # "swallow any git show failure," which would also mask a genuine read error (corrupted
+  # object, partial-clone missing blob) as an empty base_version — feeding the same tamper
+  # gate pinned_value()'s guard above protects for the plain-file case.
+  git cat-file -e "$3:$2" 2>/dev/null || return 0
+  git show "$3:$2" | grep -oE "^[[:space:]]*$1: \"[^\"]+\"" | head -n1 | sed -E 's/.*"([^"]+)".*/\1/' || true
 }
 
 if [ "$#" -gt 0 ]; then


### PR DESCRIPTION
<!-- rumdl-disable-file MD041 -->

## What

Updates the `copier-everything` template pin from `v1.9.0` to `v1.10.1` via `copier update`
(5 releases: v1.9.1, v1.9.2, v1.9.3, v1.10.0, v1.10.1). Brings in: prek version pinning
across CI/docs (kept in sync by a new Renovate custom manager), checksum tamper-gate
hardening, a label-hygiene reopen-race fix, stranded Release PR cleanup, TestPyPI
smoke-test entry-point detection, and the v1.10.0 MkDocs Material fleet baseline
(markdown extensions, strict-mode validation, custom 404 override).

## Why

Routine template-sync maintenance — closes #35.

## Verification

- [x] The quality gate passes (`uvx prek@0.4.8 run --all-files`)
- [x] `mkdocs build --strict` succeeds against the new MkDocs Material baseline
- [x] `check_docs.py` clean (no broken links/anchors, nav complete)
- [x] Full review battery run (security-review, code-reviewer, comment-analyzer,
      silent-failure-hunter, an adversarial pass, and a workflow-backed high-effort
      code-review) — clean on this repo's own diff; see below for what it surfaced
      upstream.

## Conflicts resolved during `copier update`

4 files had 3-way merge conflicts, all resolved by hand:

- **README.md** (x2 conflicts): copier's diff-merge collided the template's "Quick start"
  code blocks with this repo's pre-existing custom prose at the same anchor points.
  Confirmed via `git show HEAD~1:README.md` this repo never had those template blocks in
  the first place — resolved by keeping local prose; result is byte-identical to the
  pre-update README.
- **.config/typos.toml**, **pyproject.toml**: pure comment-wording conflicts (no functional
  change) — took upstream's newer rationale in both.
- **.gitignore**: kept both the local `.ship/` entry and upstream's new `site/` entry
  (non-overlapping).

## Decisions made without asking

- Skipped full docs-site content authoring: #30 already tracks that work, deliberately
  deferred pending nivintw/nivintw-claude-skills#107. This PR touches only the MkDocs
  *mechanism* (theme/markdown_extensions), not application surface, so there was nothing
  new to document — validated with `check_docs.py` + `mkdocs build --strict` instead.
- The review battery (independently, via 3 separate passes) found a real gap in the
  vendored `scripts/refresh-binary-checksums.sh`: `pinned_value_at_base()`'s new
  `git cat-file -e` guard doesn't actually deliver the read-error protection its own
  comment claims — a trailing `|| true` still silently disables the supply-chain
  tamper gate on a genuine `git show` failure. Since this is template-owned content that
  would just be re-clobbered on the next `copier update`, filed it upstream instead of
  hand-patching: [nivintw/copier-everything#193](https://github.com/nivintw/copier-everything/issues/193).
- The adversarial pass found two more vendored-template gaps — filed as
  [nivintw/copier-everything#195](https://github.com/nivintw/copier-everything/issues/195):
  the new "close stranded Release PRs" step in `main.yml` can destroy a human's manual
  fixup commit pushed onto a bot branch, and `label-hygiene.yml`'s reopen-race re-check has
  a narrow TOCTOU window.
- **Flagging for you, not filed upstream**: the workflow-backed review also found the
  v1.10.0 MkDocs baseline silently dropped the vendored asciinema-player
  `extra_css`/`extra_javascript` wiring, while `.config/rumdl.toml` (same update) still
  documents the `<figure class="cast">` convention as live — the two vendored files now
  disagree. No functional impact today (no casts embedded in this repo yet), so not a
  blocker, but a third upstream-issue-filing attempt was blocked by the environment's
  permission classifier as outside this task's granted scope. Worth filing upstream
  yourself, or telling me to, if you want it tracked.

Closes #35