### PR TITLE
docs: author docs site content from scratch, update template to v1.11.0

### DIFF
--- a/.config/rumdl.toml
+++ b/.config/rumdl.toml
@@ -27,3 +27,7 @@ style = "fenced"
 # code block, then "fixes" it by wrapping the tab's prose in stray fences too, destroying
 # the tab structure (see nivintw/copier-everything#178).
 "docs/*.md" = ["MD033", "MD046"]
+# MD041 (first line must be a level-1 heading): a pymdownx.snippets fragment isn't a
+# standalone page — it's spliced into whatever page includes it via `--8<--`, so forcing
+# an H1 here would inject a duplicate/wrong-level heading wherever it's included.
+"docs/includes/*.md" = ["MD041"]

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY.
-_commit: v1.10.1
+_commit: v1.11.0
 _src_path: gh:nivintw/copier-everything
 author_email: tyler@nivin.tech
 author_name: Tyler Nivin

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,4 +29,9 @@ jobs:
       contents: read
       pages: write
       id-token: write
-    uses: nivintw/repo-management/.github/workflows/docs.yml@864420032528f0d7339fe07a44630b620f16d88b # main
+    uses: nivintw/repo-management/.github/workflows/docs.yml@e1949b798ee87018f16e1a41253ff36cf34f3b98 # main
+    with:
+      # mkdocs.yml enables the git-revision-date-localized and llmstxt plugins
+      # (nivintw/repo-management#94, #97) — neither ships with mkdocs-material, so both
+      # need to be installed alongside it at build time.
+      extra-packages: mkdocs-git-revision-date-localized-plugin mkdocs-llmstxt

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ build/
 
 ### MkDocs ###
 site/
+# The social-cards plugin caches generated og:image renders here across builds.
+.cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,24 +22,3 @@ Thanks for contributing!
 ```bash
 uvx prek@0.4.8 run --all-files
 ```
-
-## Releasing
-
-Every GitHub Release triggers a publish workflow (`.github/workflows/publish.yml`) that
-builds once, publishes to **TestPyPI** first (install + import the built wheel as a smoke
-test), then — gated on that — publishes to **[PyPI](https://pypi.org/project/digital-ocean-dynamic-dns/)**.
-Auth is OIDC **Trusted Publishing** (no long-lived secret), bound to two GitHub
-**deployment environments** — `testpypi` and `pypi` — each restricted to `v*` tag
-deployments. **This only actually publishes once the one-time setup below is complete** —
-until then, the workflow runs and fails at the TestPyPI step.
-
-One-time setup before the first release:
-
-1. Create the `testpypi` and `pypi` environments (repo Settings → Environments), each with
-   a deployment branch/tag policy restricted to `v*` tags.
-2. Add a pending Trusted Publisher on [test.pypi.org](https://test.pypi.org/manage/account/publishing/)
-   and [pypi.org](https://pypi.org/manage/account/publishing/), each pointing at owner
-   `nivintw`, repo `ddns`, workflow `publish.yml`, and the matching
-   environment (`testpypi` / `pypi`).
-
-Until both publishers exist, `uv publish` fails loudly rather than silently skipping.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,12 +25,13 @@ uvx prek@0.4.8 run --all-files
 
 ## Releasing
 
-Published to **[PyPI](https://pypi.org/project/digital-ocean-dynamic-dns/)** on each GitHub Release
-(`.github/workflows/publish.yml`), dress-rehearsed through **TestPyPI** first — build once,
-publish to TestPyPI, install and import the built wheel, then (gated on that) publish to
-PyPI. Auth is OIDC **Trusted Publishing** (no long-lived secret), bound to two GitHub
+Every GitHub Release triggers a publish workflow (`.github/workflows/publish.yml`) that
+builds once, publishes to **TestPyPI** first (install + import the built wheel as a smoke
+test), then — gated on that — publishes to **[PyPI](https://pypi.org/project/digital-ocean-dynamic-dns/)**.
+Auth is OIDC **Trusted Publishing** (no long-lived secret), bound to two GitHub
 **deployment environments** — `testpypi` and `pypi` — each restricted to `v*` tag
-deployments.
+deployments. **This only actually publishes once the one-time setup below is complete** —
+until then, the workflow runs and fails at the TestPyPI step.
 
 One-time setup before the first release:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,3 +22,23 @@ Thanks for contributing!
 ```bash
 uvx prek@0.4.8 run --all-files
 ```
+
+## Releasing
+
+Published to **[PyPI](https://pypi.org/project/digital-ocean-dynamic-dns/)** on each GitHub Release
+(`.github/workflows/publish.yml`), dress-rehearsed through **TestPyPI** first — build once,
+publish to TestPyPI, install and import the built wheel, then (gated on that) publish to
+PyPI. Auth is OIDC **Trusted Publishing** (no long-lived secret), bound to two GitHub
+**deployment environments** — `testpypi` and `pypi` — each restricted to `v*` tag
+deployments.
+
+One-time setup before the first release:
+
+1. Create the `testpypi` and `pypi` environments (repo Settings → Environments), each with
+   a deployment branch/tag policy restricted to `v*` tags.
+2. Add a pending Trusted Publisher on [test.pypi.org](https://test.pypi.org/manage/account/publishing/)
+   and [pypi.org](https://pypi.org/manage/account/publishing/), each pointing at owner
+   `nivintw`, repo `ddns`, workflow `publish.yml`, and the matching
+   environment (`testpypi` / `pypi`).
+
+Until both publishers exist, `uv publish` fails loudly rather than silently skipping.

--- a/README.md
+++ b/README.md
@@ -39,29 +39,7 @@ identically locally and in CI. Conventional Commits are enforced at commit-msg t
 
 ## Installation
 
-Recommended installation path is to install this repository using [pipx](https://github.com/pypa/pipx). `pipx` provides the ability to install command line tools like this one into isolated environments, keeping your system-level packages clean and removing the possibility of dependency conflicts across tools.
-
-Another alternative option to `pipx` is the (relatively) new tool [uv](https://github.com/astral-sh/uv). See [this blog post](https://astral.sh/blog/uv-unified-python-packaging) for more information and information on the recent features added to `uv`. If going the uv route, you want `uv tool install`.
-
-## Publishing to PyPI
-
-Published to **[PyPI](https://pypi.org/project/digital-ocean-dynamic-dns/)** on each GitHub Release
-(`.github/workflows/publish.yml`), dress-rehearsed through **TestPyPI** first — build once,
-publish to TestPyPI, install and import the built wheel, then (gated on that) publish to
-PyPI. Auth is OIDC **Trusted Publishing** (no long-lived secret), bound to two GitHub
-**deployment environments** — `testpypi` and `pypi` — each restricted to `v*` tag
-deployments.
-
-One-time setup before the first release:
-
-1. Create the `testpypi` and `pypi` environments (repo Settings → Environments), each with
-   a deployment branch/tag policy restricted to `v*` tags.
-2. Add a pending Trusted Publisher on [test.pypi.org](https://test.pypi.org/manage/account/publishing/)
-   and [pypi.org](https://pypi.org/manage/account/publishing/), each pointing at owner
-   `nivintw`, repo `ddns`, workflow `publish.yml`, and the matching
-   environment (`testpypi` / `pypi`).
-
-Until both publishers exist, `uv publish` fails loudly rather than silently skipping.
+See [Getting Started](docs/getting-started.md#1-install) for install instructions (pipx or uv).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ Example:
 ## Documentation
 
 Full docs — installation, first-run setup, the complete command reference, and
-troubleshooting — live under [`docs/`](docs/index.md):
+troubleshooting — live under [`docs/`](docs/index.md). These are repo-relative links: they
+render correctly on GitHub, but not from PyPI's rendered long description (this README) —
+see [nivintw/ddns#38](https://github.com/nivintw/ddns/issues/38) to switch to absolute links
+once this content actually exists on `main` (converting now would 404 until this very PR
+merges):
 
 - [Getting Started](docs/getting-started.md) — install, configure, onboard your first domain
 - [Commands](docs/commands/index.md) — every `do_ddns` subcommand and flag

--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ Example:
 1. DigitalOcean is my authoritative name server provider for the `nivin.tech` domain.
 1. I use this package (installed as a command line utility and deployed on a device on my home network) to update the DNS records for `nivin.tech` to point at my home gateway, which is assigned a dynamic IP address by my internet service provider (ISP).
 
+## Documentation
+
+Full docs — installation, first-run setup, the complete command reference, and
+troubleshooting — live under [`docs/`](docs/index.md):
+
+- [Getting Started](docs/getting-started.md) — install, configure, onboard your first domain
+- [Commands](docs/commands/index.md) — every `do_ddns` subcommand and flag
+- [Concepts](docs/concepts.md) — the domain/subdomain/manage/catalog vocabulary
+- [Configuration](docs/configuration.md) — env vars, file locations, platform limits
+- [Troubleshooting](docs/troubleshooting.md) — common errors and fixes
+- [Roadmap](docs/roadmap.md) — known limitations and planned work
+
 This project carries the shared quality baseline: prek hooks (git hygiene, gitleaks,
 typos, rumdl, SPDX/REUSE headers, ruff, ty) that run
 identically locally and in CI. Conventional Commits are enforced at commit-msg time
@@ -54,61 +66,3 @@ Until both publishers exist, `uv publish` fails loudly rather than silently skip
 ## License
 
 [MIT](LICENSE) — and [REUSE](https://reuse.software)-compliant.
-
-## Appendix
-
-This is an appendix of the various terms used in the library.
-
-domain: A domain as described by Digital Ocean (see [Digital Ocean's DNS quickstart](https://docs.digitalocean.com/products/networking/dns/getting-started/quickstart/)).
-This is specifically a "two part" domain such as "example.com" without any sub-domains specified.
-
-subdomain: A subdomain as described by Digital Ocean (see [Digital Ocean's add-a-subdomain guide](https://docs.digitalocean.com/products/networking/dns/how-to/add-subdomain/)).
-This can be any subdomain that Digital Ocean supports.
-Subdomains must be associated with a registered and managed domain.
-
-manage (domain context): Refers specifically to having digital-ocean-dynamic-dns catalog the corresponding domain.
-Domains must be managed by digital-ocean-dynamic-dns in order to manage corresponding subdomains.
-
-manage (subdomain context): Refers specifically to having digital-ocean-dynamic-dns handle updating the IP address associated with the corresponding subdomain.
-
-un-manage (domain context): Mark the corresponding domain as un-managed in the digital-ocean-dynamic-dns local database/catalog.
-This will have the effect of un-managing (but not de-registering nor remove) the corresponding subdomains.
-
-un-manage (subdomain context): Mark the corresponding subdomain as un-managed in the digital-ocean-dynamic-dns local database/catalog.
-This will result in the IP address no longer being managed by digital-ocean-dynamic-dns.
-This does not remove the entry for the subdomain from the local digital-ocean-dynamic-dns database/catalog.
-This will not de-register the associated subdomain.
-
-remove (domain context): Removes the associated domain from the digital-ocean-dynamic-dns local database/catalog.
-This has the additional effect of removing corresponding subdomains.
-No de-register actions are taken as part of a remove action; changes are to the digital-ocean-dynamic-dns local database/catalog only.
-
-remove (subdomain context): Removes the associated subdomain from the digital-ocean-dynamic-dns local database/catalog.
-No de-register actions are taken as part of a remove action; changes are to the digital-ocean-dynamic-dns local database/catalog only.
-
-catalog: Store an entry in the digital-ocean-dynamic-dns database for the corresponding domain or subdomain.
-Domains and subdomains can be cataloged and not managed.
-
-register (subdomain context): Make changes to you Digital Ocean account to add the corresponding subdomain record to the corresponding Domain registration.
-This requires that the top domain (e.g. example.com for subdomain my.example.com) be both registered and managed.
-
-deregister (subdomain context): Make changes to your Digital Ocean account to remove the corresponding subdomain records from the corresponding Domain registration.
-This has the additional effect of removing the subdomain from the local digital-ocean-dynamic-dns database.
-
-## Planned Updates
-
-- [ ] Add support for multiple IP address resolvers.
-  - examples: `https://ip-api.com`, `https://api.whatismyip.com/ip.php?key=<API_KEY>`, etc
-- [ ] Finish updating the command line user interface.
-  - Substantial changes have already been made, and further re-writes are planned.
-  - [/] changes to using subparsers instead of overloaded command line flags.
-  - [/] Revise language to be more clear about what is being managed and how.
-  - [ ] substantial changes to argparse usage/implementation
-- [ ] Update README.md to highlight where/how this tool is intended to be used.
-- [ ] Update logging features/implementation.
-- [ ] Register and upload package to PyPI.
-- [ ] Add automated CI/CD process including package release to PyPI.
-- [ ] Integrate python-semantic-release for version management.
-- [ ] Add support for purging local database (without updating DO records).
-  - Used to just get a "fresh install".
-- [ ] Add support to read config from a toml file.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,27 @@ identically locally and in CI. Conventional Commits are enforced at commit-msg t
 
 See [Getting Started](docs/getting-started.md#1-install) for install instructions (pipx or uv).
 
+## Publishing to PyPI
+
+Every GitHub Release triggers a publish workflow (`.github/workflows/publish.yml`) that
+builds once, publishes to **TestPyPI** first (install + import the built wheel as a smoke
+test), then — gated on that — publishes to **[PyPI](https://pypi.org/project/digital-ocean-dynamic-dns/)**.
+Auth is OIDC **Trusted Publishing** (no long-lived secret), bound to two GitHub
+**deployment environments** — `testpypi` and `pypi` — each restricted to `v*` tag
+deployments. **This only actually publishes once the one-time setup below is complete** —
+until then, the workflow runs and fails at the TestPyPI step.
+
+One-time setup before the first release:
+
+1. Create the `testpypi` and `pypi` environments (repo Settings → Environments), each with
+   a deployment branch/tag policy restricted to `v*` tags.
+2. Add a pending Trusted Publisher on [test.pypi.org](https://test.pypi.org/manage/account/publishing/)
+   and [pypi.org](https://pypi.org/manage/account/publishing/), each pointing at owner
+   `nivintw`, repo `ddns`, workflow `publish.yml`, and the matching
+   environment (`testpypi` / `pypi`).
+
+Until both publishers exist, `uv publish` fails loudly rather than silently skipping.
+
 ## License
 
 [MIT](LICENSE) — and [REUSE](https://reuse.software)-compliant.

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -1,0 +1,18 @@
+<!--
+SPDX-FileCopyrightText: © 2023 Tyler Nivin
+SPDX-License-Identifier: MIT
+-->
+
+# Commands
+
+`do_ddns` is a single entry point with six subcommands. Each one is documented in full on its
+own page, linked below.
+
+| Command | Description |
+| --- | --- |
+| [`update-ips`](update-ips.md) | Check (and, if needed, update) the public IP address recorded for every managed subdomain. |
+| [`manage`](manage.md) | Start tracking a domain, or a single subdomain, so `update-ips` will keep its A-record current. |
+| [`un-manage`](un-manage.md) | Stop tracking a domain or subdomain, without touching its DNS A-record or local database entry. |
+| [`ip-resolver-config`](ip-resolver-config.md) | View or set the upstream service used to resolve your public IP address. |
+| [`show-info`](show-info.md) | Display current configuration, counts, version, and (via a sub-subcommand) all upstream domains. |
+| [`logs`](logs.md) | Print the contents of the application's log file. |

--- a/docs/commands/ip-resolver-config.md
+++ b/docs/commands/ip-resolver-config.md
@@ -1,0 +1,46 @@
+<!--
+SPDX-FileCopyrightText: © 2023 Tyler Nivin
+SPDX-License-Identifier: MIT
+-->
+
+# ip-resolver-config
+
+Views or sets the upstream service `do_ddns` calls to learn your current public IP address.
+This is one-time setup that has to happen before [`manage`](manage.md) or
+[`update-ips`](update-ips.md) can do anything useful.
+
+## Usage
+
+```bash
+do_ddns ip-resolver-config
+do_ddns ip-resolver-config --url https://api.ipify.org
+do_ddns ip-resolver-config --url https://api.ipify.org --ip-mode 4
+```
+
+## What it does
+
+| Invocation | Behavior |
+| --- | --- |
+| `ip-resolver-config` (no args) | Prints the currently configured resolver URL, or `None Configured` if none is set. Makes no changes. |
+| `ip-resolver-config --url <url>` | Sets (or overwrites) the resolver URL, then prints the resulting configuration. |
+
+The resolver is expected to respond to a `GET` request with the caller's IP address as plain
+text in the response body (for example, `https://api.ipify.org`). `--ip-mode` defaults to `4`
+and only one resolver is stored at a time — setting a new URL overwrites the previous one.
+
+## When to reach for it
+
+Run this once, right after installing `do_ddns` and before your first `manage` call — nothing
+that resolves an IP address will work without it. Re-run it later only if you need to switch
+resolver services (for example, if your current one goes down).
+
+!!! warning
+    `--ip-mode 6` raises a hard error today — `IPv6NotSupportedError`. IPv4 is the only
+    supported mode; don't pass `--ip-mode 6` expecting it to work.
+
+## Related
+
+- [manage](manage.md) — the next step once a resolver is configured.
+- [update-ips](update-ips.md) — also depends on a configured resolver to know the current IP.
+- [Getting Started: set up an IP resolver](../getting-started.md#3-set-up-an-ip-resolver-one-time) —
+  a walkthrough of this one-time setup step.

--- a/docs/commands/logs.md
+++ b/docs/commands/logs.md
@@ -1,0 +1,35 @@
+<!--
+SPDX-FileCopyrightText: © 2023 Tyler Nivin
+SPDX-License-Identifier: MIT
+-->
+
+# logs
+
+Dumps the current contents of `do_ddns`'s log file to the console.
+
+## Usage
+
+```bash
+do_ddns logs
+```
+
+Takes no arguments.
+
+## What it does
+
+1. Opens the application's log file (INFO-level Python logging, populated primarily by
+   [`update-ips`](update-ips.md) runs).
+2. Reads its entire current contents.
+3. Prints it as-is — no filtering, tailing, or formatting.
+
+## When to reach for it
+
+Reach for this after a scheduled `update-ips` run to confirm it actually ran and whether it
+found anything to update, or when diagnosing why records aren't updating as expected. It's a
+full dump rather than a tail, so on a long-lived install expect to pipe the output through your
+own pager or filter.
+
+## Related
+
+- [show-info](show-info.md) — shows the log file's on-disk location.
+- [Configuration](../configuration.md) — documents the log file's location and format in full.

--- a/docs/commands/manage.md
+++ b/docs/commands/manage.md
@@ -1,0 +1,59 @@
+<!--
+SPDX-FileCopyrightText: © 2023 Tyler Nivin
+SPDX-License-Identifier: MIT
+-->
+
+# manage
+
+Brings a domain, or a single subdomain of it, under `do_ddns` management so that
+[`update-ips`](update-ips.md) will keep its A-record pointed at your current public IP.
+
+## Usage
+
+```bash
+do_ddns manage example.com
+do_ddns manage example.com --subdomain home
+do_ddns manage example.com --subdomain home.example.com
+do_ddns manage example.com --list
+```
+
+`--subdomain` and `--list` are mutually exclusive.
+
+## What it does
+
+| Invocation | Behavior |
+| --- | --- |
+| `manage <domain>` | Imports and manages **every** existing A-record already registered upstream for `<domain>`. |
+| `manage <domain> --subdomain <name>` | Manages just `<name>`: claims the existing A-record if one exists upstream, or creates a new one if it doesn't. |
+| `manage <domain> --list` | Prints managed and unmanaged A-records for `<domain>`. Read-only — makes no changes. |
+
+In every mode, `manage` first ensures `<domain>` itself is registered as a managed top-level
+domain (verifying it's actually registered on your DigitalOcean account before inserting it,
+or doing nothing if it's already managed). Only after that does it act on `--subdomain` /
+`--list` / the bare-domain import.
+
+A subdomain name can be given bare (`home`) or fully-qualified (`home.example.com`) — `do_ddns`
+strips the `.example.com` suffix automatically either way, so both forms are equivalent.
+
+## When to reach for it
+
+Use the bare form (`manage example.com`) when you already have A-records for a domain and want
+`do_ddns` to take over updating all of them. Use `--subdomain` when you're onboarding one new
+subdomain at a time, or when a domain has other A-records you don't want `do_ddns` touching.
+Use `--list` any time you just want to check current state without side effects — it's the
+per-domain counterpart to [`show-info`](show-info.md)'s account-wide summary.
+
+!!! note
+    The top-level domain is *always* attempted first, regardless of mode. Running
+    `do_ddns manage example.com --subdomain home` manages **both** `example.com` and
+    `home.example.com` in one call — you never need a separate step to manage the parent
+    domain first.
+
+## Related
+
+- [update-ips](update-ips.md) — run this after `manage` to push the first update immediately,
+  and on a schedule afterward.
+- [un-manage](un-manage.md) — the inverse: stop tracking a domain or subdomain.
+- [ip-resolver-config](ip-resolver-config.md) — configure an IP resolver first; `manage` needs
+  one to create or claim an A-record.
+- [Concepts](../concepts.md) — the domain/subdomain/manage/catalog vocabulary used throughout.

--- a/docs/commands/manage.md
+++ b/docs/commands/manage.md
@@ -29,8 +29,10 @@ do_ddns manage example.com --list
 
 In every mode, `manage` first ensures `<domain>` itself is registered as a managed top-level
 domain (verifying it's actually registered on your DigitalOcean account before inserting it,
-or doing nothing if it's already managed). Only after that does it act on `--subdomain` /
-`--list` / the bare-domain import.
+or doing nothing if it's already managed) — so `do_ddns manage example.com --subdomain home`
+manages **both** `example.com` and `home.example.com` in one call, with no separate step
+needed for the parent domain. Only after that does it act on `--subdomain` / `--list` / the
+bare-domain import.
 
 A subdomain name can be given bare (`home`) or fully-qualified (`home.example.com`) — `do_ddns`
 strips the `.example.com` suffix automatically either way, so both forms are equivalent.
@@ -42,12 +44,6 @@ Use the bare form (`manage example.com`) when you already have A-records for a d
 subdomain at a time, or when a domain has other A-records you don't want `do_ddns` touching.
 Use `--list` any time you just want to check current state without side effects — it's the
 per-domain counterpart to [`show-info`](show-info.md)'s account-wide summary.
-
-!!! note
-    The top-level domain is *always* attempted first, regardless of mode. Running
-    `do_ddns manage example.com --subdomain home` manages **both** `example.com` and
-    `home.example.com` in one call — you never need a separate step to manage the parent
-    domain first.
 
 ## Related
 

--- a/docs/commands/show-info.md
+++ b/docs/commands/show-info.md
@@ -1,0 +1,54 @@
+<!--
+SPDX-FileCopyrightText: © 2023 Tyler Nivin
+SPDX-License-Identifier: MIT
+-->
+
+# show-info
+
+Prints a summary of the current `do_ddns` configuration and installation: API key status, IP
+resolver, log file location, domain/subdomain counts, and app version.
+
+## Usage
+
+```bash
+do_ddns show-info
+do_ddns show-info --show-api-key
+do_ddns show-info --no-show-api-key  # explicit form of the default
+do_ddns show-info domains
+```
+
+`--show-api-key` / `--no-show-api-key` is a
+[`BooleanOptionalAction`](https://docs.python.org/3/library/argparse.html#argparse.BooleanOptionalAction);
+the default is `--no-show-api-key`.
+
+## What it does
+
+| Invocation | Behavior |
+| --- | --- |
+| `show-info` | Prints a table: API key status (configured/missing, masked unless `--show-api-key`), configured IPv4 resolver, log file path, total domain count, total subdomain ("A" record) count, and app version. |
+| `show-info --show-api-key` | Same table, but with the actual API key value shown instead of `Configured`. |
+| `show-info domains` | Lists every domain registered on the DigitalOcean account, one per line, marking each one already cataloged locally with `[*]`. |
+
+The `[*]` marker on `show-info domains` reflects whether the domain has a row in the local
+database at all — cataloging alone is enough to earn the marker, whether or not the domain is
+currently `managed`.
+
+## When to reach for it
+
+Reach for the bare form as a health check: confirm the API key is set, a resolver is
+configured, and see how many domains/subdomains are tracked, without digging into per-domain
+detail. Reach for `show-info domains` specifically when you need to see the full list of
+domains available on the account — including ones `do_ddns` has never touched — before
+deciding what to [`manage`](manage.md).
+
+!!! note
+    `show-info domains` marks a domain cataloged, not necessarily managed. A domain you
+    previously `un-manage`d still shows `[*]` here, since un-managing never removes its
+    database row.
+
+## Related
+
+- [logs](logs.md) — the log file path shown here is the same file `logs` prints.
+- [manage](manage.md) — `manage <domain> --list` gives per-domain subdomain detail; `show-info`
+  gives the account-wide summary.
+- [Configuration](../configuration.md) — where the log file, API key, and database live on disk.

--- a/docs/commands/show-info.md
+++ b/docs/commands/show-info.md
@@ -31,7 +31,8 @@ the default is `--no-show-api-key`.
 
 The `[*]` marker on `show-info domains` reflects whether the domain has a row in the local
 database at all — cataloging alone is enough to earn the marker, whether or not the domain is
-currently `managed`.
+currently `managed`. A domain you previously `un-manage`d still shows `[*]` here, since
+un-managing never removes its database row.
 
 ## When to reach for it
 
@@ -40,11 +41,6 @@ configured, and see how many domains/subdomains are tracked, without digging int
 detail. Reach for `show-info domains` specifically when you need to see the full list of
 domains available on the account — including ones `do_ddns` has never touched — before
 deciding what to [`manage`](manage.md).
-
-!!! note
-    `show-info domains` marks a domain cataloged, not necessarily managed. A domain you
-    previously `un-manage`d still shows `[*]` here, since un-managing never removes its
-    database row.
 
 ## Related
 

--- a/docs/commands/un-manage.md
+++ b/docs/commands/un-manage.md
@@ -1,0 +1,52 @@
+<!--
+SPDX-FileCopyrightText: © 2023 Tyler Nivin
+SPDX-License-Identifier: MIT
+-->
+
+# un-manage
+
+Stops `do_ddns` from tracking a domain or subdomain, so future
+[`update-ips`](update-ips.md) runs no longer touch its A-record.
+
+## Usage
+
+```bash
+do_ddns un-manage example.com
+do_ddns un-manage example.com --subdomain home
+do_ddns un-manage example.com --subdomain home.example.com
+do_ddns un-manage example.com --list
+```
+
+`--subdomain` and `--list` are mutually exclusive — this mirrors [`manage`](manage.md)'s shape
+exactly.
+
+## What it does
+
+| Invocation | Behavior |
+| --- | --- |
+| `un-manage <domain>` | Un-manages `<domain>` **and** cascades to every subdomain currently managed under it. |
+| `un-manage <domain> --subdomain <name>` | Un-manages only `<name>`; the parent domain and any other subdomains are untouched. |
+| `un-manage <domain> --list` | Prints managed and unmanaged A-records for `<domain>`. Read-only — makes no changes. |
+
+As with `manage`, a subdomain name can be given bare (`home`) or fully-qualified
+(`home.example.com`) — the domain suffix is stripped automatically.
+
+## When to reach for it
+
+Use the bare form when you're walking away from a domain entirely — it un-manages the domain
+and every subdomain under it in one call. Use `--subdomain` to drop a single subdomain while
+leaving the rest of the domain's records under management (for example, decommissioning one
+host but keeping others current).
+
+!!! warning
+    `un-manage` does **not** delete the DNS A-record from DigitalOcean, and does not remove the
+    row from the local database. It only flips a `managed` flag off, so `update-ips` skips it
+    going forward. The record stays live upstream at whatever IP it last had. See
+    [Concepts](../concepts.md) for how manage/un-manage relate to cataloging and actual removal.
+
+## Related
+
+- [manage](manage.md) — the inverse: start tracking a domain or subdomain again.
+- [update-ips](update-ips.md) — un-managed subdomains are the ones this command will now skip.
+- [Concepts](../concepts.md) — the manage vs. un-manage vs. catalog vs. remove distinction,
+  spelled out in full.

--- a/docs/commands/update-ips.md
+++ b/docs/commands/update-ips.md
@@ -1,0 +1,57 @@
+<!--
+SPDX-FileCopyrightText: © 2023 Tyler Nivin
+SPDX-License-Identifier: MIT
+-->
+
+# update-ips
+
+Resolves your current public IP address and reconciles it against every subdomain
+`do_ddns` is managing, updating only the DigitalOcean A-records that have drifted. This is
+the command meant to run unattended, on a schedule.
+
+## Usage
+
+```bash
+do_ddns update-ips
+do_ddns update-ips --force
+do_ddns update-ips --no-force  # explicit form of the default
+```
+
+`-f` is a short form of `--force`. Both flags are a
+[`BooleanOptionalAction`](https://docs.python.org/3/library/argparse.html#argparse.BooleanOptionalAction),
+so `--force` / `--no-force` are both accepted; the default is `--no-force`.
+
+## What it does
+
+1. Reads every subdomain currently marked `managed` in the local database. If there are none,
+   it aborts before making any network calls (see the note below).
+2. Resolves the host's current public IP address via the configured IPv4 resolver.
+3. For each managed subdomain, fetches its A-record from the DigitalOcean API and compares the
+   recorded IP against the current one.
+4. If the IPs differ, or `--force` was given, it pushes an update to that A-record and updates
+   the subdomain's `current_ip4` / `last_updated` / `last_checked` timestamps in the local
+   database. If the IPs already match and `--force` was not given, it only updates
+   `last_checked`.
+5. Prints a one-line summary: either `No updates necessary` or `Updates done.` depending on
+   whether any A-record actually changed.
+
+## When to reach for it
+
+This is the one command meant to run on a recurring schedule (cron, a systemd timer, ...) —
+everything else here is one-time or occasional setup. Use `--force` only when you need to
+push the current IP even though `do_ddns` believes the record is already current (for example,
+after manually editing a record in the DigitalOcean dashboard).
+
+!!! note
+    `update-ips` raises an error if zero subdomains are currently managed — it will not
+    silently no-op. Run [`manage`](manage.md) first to bring at least one subdomain under
+    management.
+
+## Related
+
+- [manage](manage.md) — run this first if no subdomains are managed yet; `update-ips` refuses
+  to run with nothing to check.
+- [ip-resolver-config](ip-resolver-config.md) — `update-ips` also depends on a configured IP
+  resolver; configure one before scheduling updates.
+- [Getting Started: keep it updated](../getting-started.md#5-keep-it-updated) — the cron/systemd
+  recipe for running this command automatically.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,57 @@
+<!--
+SPDX-FileCopyrightText: © 2023 Tyler Nivin
+SPDX-License-Identifier: MIT
+-->
+
+# Concepts
+
+`digital-ocean-dynamic-dns` tracks its own state locally (in a SQLite database — see
+[Configuration](configuration.md)) alongside whatever's actually registered with
+DigitalOcean. The vocabulary below distinguishes what's tracked *locally* from what's
+changed *upstream* — mixing these up is the most common source of confusion.
+
+## Domain and subdomain
+
+**Domain** — a two-part domain (`example.com`) as
+[DigitalOcean defines it](https://docs.digitalocean.com/products/networking/dns/getting-started/quickstart/).
+
+**Subdomain** — any subdomain of a managed domain
+([DigitalOcean's definition](https://docs.digitalocean.com/products/networking/dns/how-to/add-subdomain/)),
+e.g. `home.example.com`. A subdomain can only be tracked once its top-level domain is
+managed.
+
+## Catalog, manage, and un-manage
+
+These three actions only touch the **local database** — none of them change anything on
+DigitalOcean by themselves.
+
+| Term | Domain context | Subdomain context |
+| --- | --- | --- |
+| **catalog** | Store a domain entry in the local database, without tracking IP updates for it. | Store a subdomain entry in the local database, without tracking IP updates for it. |
+| **manage** | Catalog the domain *and* mark it eligible for subdomain tracking — a domain must be managed before any of its subdomains can be. | Catalog the subdomain *and* have `update-ips` keep its DigitalOcean A-record pointed at your current public IP. |
+| **un-manage** | Mark the domain (and cascade to all its currently-managed subdomains) as no longer tracked. Does **not** delete the database entry or touch DigitalOcean. | Stop `update-ips` from touching this subdomain's A-record. Does **not** delete the database entry or touch DigitalOcean. |
+
+In practice: `do_ddns manage example.com` catalogs and manages the domain in one step (see
+[`manage`](commands/manage.md)) — you won't usually catalog something without also managing
+it, but the distinction matters for [`show-info domains`](commands/show-info.md), which
+marks *cataloged* domains regardless of whether they're actively managed.
+
+## Register, deregister, and remove — not yet implemented as commands
+
+Three more terms exist in this project's vocabulary but don't have a dedicated CLI command
+today:
+
+- **register** (subdomain context) — creating or claiming the actual DigitalOcean A-record
+  for a subdomain. This happens as a *side effect* of [`manage`](commands/manage.md) (it
+  creates the record if it doesn't exist, or claims an existing one) — there's no standalone
+  `register` command.
+- **deregister** (subdomain context) — removing a subdomain's A-record from DigitalOcean.
+  No command does this yet; [`un-manage`](commands/un-manage.md) only stops local tracking,
+  it never deletes anything on DigitalOcean.
+- **remove** (domain/subdomain context) — deleting the local database entry entirely (as
+  opposed to un-managing, which keeps the entry but marks it untracked). No command does
+  this yet either.
+
+If you need to delete a subdomain's A-record or database entry today, do it directly in the
+DigitalOcean control panel / API — this tool won't touch it once un-managed. See the
+[Roadmap](roadmap.md) for planned work in this area.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -36,7 +36,7 @@ In practice: `do_ddns manage example.com` catalogs and manages the domain in one
 it, but the distinction matters for [`show-info domains`](commands/show-info.md), which
 marks *cataloged* domains regardless of whether they're actively managed.
 
-## Register, deregister, and remove — not yet implemented as commands
+## Register, deregister, and remove: not yet implemented as commands
 
 Three more terms exist in this project's vocabulary but don't have a dedicated CLI command
 today:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,79 @@
+<!--
+SPDX-FileCopyrightText: © 2023 Tyler Nivin
+SPDX-License-Identifier: MIT
+-->
+
+# Configuration
+
+Reference for everything `do_ddns` reads or stores to do its job: the API token, the IP resolver,
+and the files it keeps on disk.
+
+## API token
+
+`do_ddns` needs a DigitalOcean [Personal Access Token](https://docs.digitalocean.com/reference/api/create-personal-access-token/)
+with DNS read/write scope, provided via the `DIGITALOCEAN_TOKEN` environment variable:
+
+```bash
+export DIGITALOCEAN_TOKEN=<your-do-token>
+```
+
+This is the only configuration path today — there's no config-file support yet. `DIGITALOCEAN_TOKEN`
+is the same environment variable name DigitalOcean's own [`pydo`](https://pydo.readthedocs.io/en/latest/)
+library uses, by design, so tooling already configured for `pydo` works with `do_ddns` for free.
+Config-file support is tracked as a possible future improvement — see the [roadmap](roadmap.md).
+
+If the variable isn't set, every command that needs to talk to the DigitalOcean API fails
+immediately. See [Troubleshooting](troubleshooting.md#noapikeyerror) for the exact error and fix.
+
+## IP resolver
+
+`do_ddns` learns your public IP by making a GET request to a URL you configure and reading the
+plain-text response body. Unlike the API token, this isn't an environment variable — it's set
+with a command and stored in the local SQLite database:
+
+```bash
+do_ddns ip-resolver-config --url https://api.ipify.org
+```
+
+See the [`ip-resolver-config` command reference](commands/ip-resolver-config.md) for the full set
+of options.
+
+Only IPv4 is functional today. Passing `--ip-mode 6` is a hard error
+(`IPv6NotSupportedError`) — see [Troubleshooting](troubleshooting.md#ipv6notsupportederror) and the
+[roadmap](roadmap.md) for the current state of IPv6 support.
+
+## Local data & files
+
+`do_ddns` computes where to keep its state using the [XDG Base Directory](https://specifications.freedesktop.org/basedir-spec/latest/index.html)
+convention: `$XDG_DATA_HOME` if it's set, otherwise `~/.local/share`, namespaced under
+`tech.nivin.digital-ocean-dynamic-dns/`.
+
+| File | Default location | Purpose |
+| --- | --- | --- |
+| `do_ddns.db` | `~/.local/share/tech.nivin.digital-ocean-dynamic-dns/do_ddns.db` | SQLite database holding all persisted state (IP resolver, managed domains/subdomains). |
+| `do_ddns.log` | `~/.local/share/tech.nivin.digital-ocean-dynamic-dns/do_ddns.log` | Plain-text log file, INFO level, appended to via Python's standard `logging` module. |
+
+If `XDG_DATA_HOME` is set, both files live under `$XDG_DATA_HOME/tech.nivin.digital-ocean-dynamic-dns/`
+instead. Use `do_ddns logs` to print the log file's contents from the CLI.
+
+## Database schema
+
+The SQLite database (`do_ddns.db`) has three tables:
+
+- **`ipservers`** — the configured IP resolver (URL and IP version). Written by
+  `ip-resolver-config`.
+- **`domains`** — a catalog of domains `do_ddns` knows about, each flagged managed or unmanaged.
+  Written by `manage`/`un-manage`.
+- **`subdomains`** — a catalog of subdomains (A records) `do_ddns` knows about, each flagged
+  managed or unmanaged, along with the DigitalOcean A-record ID it corresponds to. Written by
+  `manage`/`un-manage`.
+
+This is a brief orientation for troubleshooting, not a full schema reference — the database is an
+implementation detail and its exact columns may change between releases.
+
+## Platform support
+
+**Windows is not supported today.** `do_ddns` raises a hard error on startup on Windows, before it
+does anything else. If you're on Windows, this tool won't run — there's no workaround short of
+running it under WSL or a Linux/macOS environment. Linux and macOS are both supported via the XDG
+convention described above.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -125,9 +125,9 @@ intervention.
     systemctl --user enable --now do-ddns-update.timer
     ```
 
-On macOS, either adapt the cron example above (macOS ships `cron`) or use `launchd` — see Apple's
-[`launchd.plist` documentation](https://ss64.com/mac/launchd.html) for details on writing a
-launch agent.
+On macOS, either adapt the cron example above (macOS ships `cron`) or use `launchd` — see
+[Apple's Creating Launch Daemons and Agents guide](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html)
+for details on writing a launch agent.
 
 ## 6. Inspect state
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,138 @@
+<!--
+SPDX-FileCopyrightText: © 2023 Tyler Nivin
+SPDX-License-Identifier: MIT
+-->
+
+# Getting Started
+
+This walks through installing `do_ddns`, configuring it, and getting your first domain under
+management.
+
+## 1. Install
+
+`do_ddns` is published on PyPI as `digital-ocean-dynamic-dns` and requires Python >= 3.12. Install
+it as an isolated CLI tool rather than into a project environment:
+
+=== "pipx"
+
+    ```bash
+    pipx install digital-ocean-dynamic-dns
+    ```
+
+=== "uv"
+
+    ```bash
+    uv tool install digital-ocean-dynamic-dns
+    ```
+
+Either gives you a `do_ddns` command on your `PATH`.
+
+## 2. Configure your API token
+
+`do_ddns` needs a DigitalOcean [Personal Access Token](https://docs.digitalocean.com/reference/api/create-personal-access-token/)
+with DNS read/write scope. Export it as an environment variable:
+
+```bash
+export DIGITALOCEAN_TOKEN=<your-do-token>
+```
+
+`DIGITALOCEAN_TOKEN` is the same environment variable name DigitalOcean's own [`pydo`](https://pydo.readthedocs.io/en/latest/)
+library uses, by design — if you already have DigitalOcean tooling configured this way, `do_ddns`
+picks it up for free.
+
+## 3. Set up an IP resolver (one-time)
+
+`do_ddns` figures out your current public IP by making a GET request to a URL you configure and
+reading the plain-text response body. Point it at any service that returns your IP as plain text:
+
+```bash
+do_ddns ip-resolver-config --url https://api.ipify.org
+```
+
+Any URL that responds to a GET with your IP address as plain text works. Only IPv4 is supported
+today.
+
+## 4. Onboard a domain
+
+Tell `do_ddns` which domain (and optionally which subdomain) to manage:
+
+```bash
+# Import and manage every existing A record on the domain
+do_ddns manage example.com
+
+# Or manage just one subdomain
+do_ddns manage example.com --subdomain home
+```
+
+See the [`manage` command reference](commands/manage.md) for the full set of options, including
+listing and un-managing records.
+
+## 5. Keep it updated
+
+Running the update once:
+
+```bash
+do_ddns update-ips
+```
+
+checks your current public IP and pushes any changes to the A-records you're managing. In
+practice you want this running on a schedule so your DNS stays current without manual
+intervention.
+
+### Scheduling `update-ips`
+
+=== "cron"
+
+    Add a crontab entry to run every 15 minutes:
+
+    ```cron
+    */15 * * * * do_ddns update-ips
+    ```
+
+    Make sure `DIGITALOCEAN_TOKEN` is available to the cron environment (e.g. by setting it in the
+    crontab itself or sourcing it from a file), since cron jobs don't inherit your interactive
+    shell's environment.
+
+=== "systemd timer"
+
+    Create a service unit, `~/.config/systemd/user/do-ddns-update.service`:
+
+    ```ini
+    [Unit]
+    Description=Update DigitalOcean dynamic DNS records
+
+    [Service]
+    Type=oneshot
+    Environment=DIGITALOCEAN_TOKEN=<your-do-token>
+    ExecStart=%h/.local/bin/do_ddns update-ips
+    ```
+
+    And a matching timer, `~/.config/systemd/user/do-ddns-update.timer`:
+
+    ```ini
+    [Unit]
+    Description=Run do-ddns-update every 15 minutes
+
+    [Timer]
+    OnBootSec=5min
+    OnUnitActiveSec=15min
+
+    [Install]
+    WantedBy=timers.target
+    ```
+
+    Enable and start the timer:
+
+    ```bash
+    systemctl --user enable --now do-ddns-update.timer
+    ```
+
+On macOS, either adapt the cron example above (macOS ships `cron`) or use `launchd` — see Apple's
+[`launchd.plist` documentation](https://ss64.com/mac/launchd.html) for details on writing a
+launch agent.
+
+## 6. Inspect state
+
+`do_ddns show-info` prints your current configuration (API key status, IP resolver, version), and
+`do_ddns logs` prints the tool's logs. See the [Commands reference](commands/index.md) for the
+full set of subcommands and flags.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,21 +36,19 @@ with DNS read/write scope. Export it as an environment variable:
 export DIGITALOCEAN_TOKEN=<your-do-token>
 ```
 
-`DIGITALOCEAN_TOKEN` is the same environment variable name DigitalOcean's own [`pydo`](https://pydo.readthedocs.io/en/latest/)
-library uses, by design — if you already have DigitalOcean tooling configured this way, `do_ddns`
-picks it up for free.
+See [Configuration: API token](configuration.md#api-token) for why this specific variable
+name was chosen and what happens if it's unset.
 
 ## 3. Set up an IP resolver (one-time)
 
-`do_ddns` figures out your current public IP by making a GET request to a URL you configure and
-reading the plain-text response body. Point it at any service that returns your IP as plain text:
+Point `do_ddns` at a service that reports your public IP:
 
 ```bash
 do_ddns ip-resolver-config --url https://api.ipify.org
 ```
 
-Any URL that responds to a GET with your IP address as plain text works. Only IPv4 is supported
-today.
+See the [`ip-resolver-config` command reference](commands/ip-resolver-config.md) for how the
+resolver works and its full set of options. Only IPv4 is supported today.
 
 ## 4. Onboard a domain
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,22 +10,7 @@ management.
 
 ## 1. Install
 
-`do_ddns` is published on PyPI as `digital-ocean-dynamic-dns` and requires Python >= 3.12. Install
-it as an isolated CLI tool rather than into a project environment:
-
-=== "pipx"
-
-    ```bash
-    pipx install digital-ocean-dynamic-dns
-    ```
-
-=== "uv"
-
-    ```bash
-    uv tool install digital-ocean-dynamic-dns
-    ```
-
-Either gives you a `do_ddns` command on your `PATH`.
+--8<-- "install.md"
 
 ## 2. Configure your API token
 

--- a/docs/includes/install.md
+++ b/docs/includes/install.md
@@ -1,0 +1,25 @@
+<!--
+SPDX-FileCopyrightText: © 2023 Tyler Nivin
+SPDX-License-Identifier: MIT
+-->
+
+<!-- Shared content fragment, included via pymdownx.snippets (`--8<-- "install.md"`) from
+     any docs page that needs install instructions, so they can't drift between copies
+     (nivintw/repo-management#96). -->
+
+`do_ddns` is published on PyPI as `digital-ocean-dynamic-dns` and requires Python >= 3.12.
+Install it as an isolated CLI tool rather than into a project environment:
+
+=== "pipx"
+
+    ```bash
+    pipx install digital-ocean-dynamic-dns
+    ```
+
+=== "uv"
+
+    ```bash
+    uv tool install digital-ocean-dynamic-dns
+    ```
+
+Either gives you a `do_ddns` command on your `PATH`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,4 +5,29 @@ SPDX-License-Identifier: MIT
 
 # Digital Ocean Dynamic DNS
 
-Python-based CLI tool for managing dynamic dns with Digital Ocean.
+`do_ddns` keeps DigitalOcean DNS A-records pointed at a network with a dynamic IP address. It
+polls your public IP and, when it changes, updates the A-records you've told it to manage — so a
+domain hosted on DigitalOcean keeps resolving to your home (or any residential) connection without
+you touching anything by hand.
+
+This is for self-hosters: if your ISP doesn't give you a static IP but you still want a stable
+domain name pointing at a server, NAS, or gateway on your network, this tool closes that gap.
+
+## At a glance
+
+```bash
+export DIGITALOCEAN_TOKEN=<your-do-token>
+do_ddns ip-resolver-config --url https://api.ipify.org
+do_ddns manage example.com --subdomain home
+do_ddns update-ips
+```
+
+That's a one-time setup followed by the command you'd run on a schedule (cron, a systemd timer,
+...) to keep records current.
+
+## Where to next
+
+- **[Getting Started](getting-started.md)** — install, configure, and onboard your first domain,
+  including scheduling `update-ips` to run automatically.
+- **[Commands](commands/index.md)** — full reference for every `do_ddns` subcommand and flag.
+- **[Concepts](concepts.md)** — the domain/subdomain/manage/catalog vocabulary this tool uses.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,54 @@
+<!--
+SPDX-FileCopyrightText: © 2023 Tyler Nivin
+SPDX-License-Identifier: MIT
+-->
+
+# Roadmap & known limitations
+
+What this tool doesn't do yet, verified against the current codebase — not a wishlist, a
+status page.
+
+## Known limitations today
+
+- **Windows isn't supported.** The tool raises an error on startup on anything other than
+  Linux or macOS.
+- **Only IPv4 is supported.** [`ip-resolver-config --ip-mode 6`](commands/ip-resolver-config.md)
+  raises an error rather than working.
+- **Only one IP resolver at a time.** You can't configure a fallback/secondary resolver
+  service — see [Configuration](configuration.md).
+- **No config file.** All configuration is the `DIGITALOCEAN_TOKEN` environment variable
+  plus CLI flags and locally-stored settings — see [Configuration](configuration.md).
+- **No `remove`/`register`/`deregister` commands.** [`manage`](commands/manage.md) and
+  [`un-manage`](commands/un-manage.md) are the only local state changes available today —
+  see [Concepts](concepts.md#register-deregister-and-remove-not-yet-implemented-as-commands)
+  for what's missing and why.
+
+## Planned work
+
+- Support multiple IP resolvers (e.g. a fallback service if the primary is unreachable).
+- Continue revising the CLI: the move to argparse subparsers and clearer manage/un-manage
+  language are done; further argparse-usage cleanup is still planned.
+- Update the logging implementation (currently a single INFO-level log file with no
+  rotation or structured output).
+- Add support for purging the local database — a clean "fresh install" without touching
+  DigitalOcean.
+- Add support for reading configuration from a TOML file, instead of environment variables
+  and CLI flags alone.
+
+## Already done (superseded items from the original roadmap)
+
+A few earlier goals are already live, in some cases via a different tool than originally
+planned:
+
+- **Published to PyPI** — released as
+  [`digital-ocean-dynamic-dns`](https://pypi.org/project/digital-ocean-dynamic-dns/).
+- **Automated releases** — release-please cuts tagged GitHub Releases from Conventional
+  Commits on every merge to `main`. The originally-planned tool for this was
+  python-semantic-release; release-please was used instead.
+- **Automated PyPI publish pipeline (wired, not yet fully live)** — a publish workflow
+  exists that builds once and pushes to TestPyPI then PyPI via OIDC Trusted Publishing, but
+  the one-time PyPI/TestPyPI Trusted Publisher registration is still outstanding, so the
+  last release didn't actually publish through it. Tracked separately, not a docs concern.
+
+Have an idea, or hit one of the limitations above harder than expected? Open an issue on
+[nivintw/ddns](https://github.com/nivintw/ddns/issues).

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: © 2023 Tyler Nivin
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Material's default `.md-typeset code { word-break: break-word }` breaks long
+   identifiers (e.g. `project_name`) mid-word inside a narrow table column. Tables already
+   handle overflow themselves (`.md-typeset table:not([class]) { overflow: auto }`), so
+   scoping code spans back to their normal no-break behavior lets a too-wide table scroll
+   horizontally instead of mangling the identifier. */
+
+.md-typeset table code {
+  word-break: normal;
+  white-space: nowrap;
+}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,7 +31,7 @@ export DIGITALOCEAN_TOKEN=<your-do-token>
 environment — cron and systemd don't inherit your interactive shell) that `do_ddns` is running in.
 See [Configuration](configuration.md#api-token) for details.
 
-### `NoIPResolverServerError`
+## `NoIPResolverServerError`
 
 **Looks like:**
 
@@ -49,7 +49,7 @@ do_ddns ip-resolver-config --url https://api.ipify.org
 an IP resolver configured first, and none has been set yet. See the
 [`ip-resolver-config` command reference](commands/ip-resolver-config.md).
 
-#### `TopDomainNotManagedError`
+## `TopDomainNotManagedError`
 
 This has two different causes depending on which command raised it — check which one you ran.
 
@@ -80,7 +80,7 @@ can't hit this. If you see it, please
 **Cause:** internal code tried to manage or un-manage a subdomain whose top-level domain isn't
 marked as managed (`un-manage`) or managed at all (`manage`) in the local database.
 
-#### `NoManagedSubdomainsError`
+## `NoManagedSubdomainsError`
 
 **Looks like:**
 
@@ -98,7 +98,7 @@ do_ddns manage example.com --subdomain home
 **Cause:** `update-ips` was run but zero subdomains are currently managed, so there's nothing to
 update. See the [`manage` command reference](commands/manage.md).
 
-#### `IPv6NotSupportedError`
+## `IPv6NotSupportedError`
 
 **Looks like:**
 
@@ -115,7 +115,7 @@ do_ddns ip-resolver-config --url https://api.ipify.org --ip-mode 4
 **Cause:** `ip-resolver-config --ip-mode 6` was used. IPv6 isn't supported yet — see the
 [roadmap](roadmap.md) for the current state of IPv6 support.
 
-#### `NonSimpleDomainNameError`
+## `NonSimpleDomainNameError`
 
 **Looks like:**
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,8 +5,13 @@ SPDX-License-Identifier: MIT
 
 # Troubleshooting
 
-If `do_ddns` exited with a traceback or a red `Error:` message, find it below. Each entry leads
-with the fix.
+If `do_ddns` exited with a red `Error:` message, find it below. Each entry leads with the fix.
+
+!!! note
+    Except for `show-info`, none of these errors are caught internally — the friendly message
+    below is followed by a full Python traceback. That traceback is expected; the line
+    starting with `Error:` (or the API key message for `NoAPIKeyError`) is the part that
+    matters.
 
 #### `NoAPIKeyError`
 
@@ -46,7 +51,20 @@ an IP resolver configured first, and none has been set yet. See the
 
 #### `TopDomainNotManagedError`
 
-**Looks like:**
+This has two different causes depending on which command raised it — check which one you ran.
+
+**From [`un-manage`](commands/un-manage.md) `--subdomain`:**
+
+```text
+Error: example.com is not a managed domain.
+```
+
+**Fix:** this is a normal usage error, not a bug — you ran `un-manage --subdomain` against a
+domain `do_ddns` has never cataloged (a typo in the domain name, or a domain you never
+[`manage`](commands/manage.md)d in the first place). Double-check the domain name, or run
+`do_ddns manage <domain>` first if you meant to catalog it.
+
+**From [`manage`](commands/manage.md) `--subdomain` (or `--list`):**
 
 ```text
 Error: example.com is not a managed domain. We do not expect users to ever be exposed to this
@@ -54,13 +72,13 @@ error. If you see this in the console while using digital-ocean-dynamic-dns plea
 on the repository.
 ```
 
-**Fix:** this shouldn't happen through normal CLI use — `manage` and `un-manage` always ensure the
-top-level domain is managed before touching a subdomain. If you hit this, please
-[file an issue](https://github.com/nivintw/ddns/issues) with the command you ran; it points at a
-bug rather than something you did wrong.
+**Fix:** this genuinely shouldn't happen — `manage` always manages the top-level domain itself
+before touching a subdomain (see [manage](commands/manage.md)), so a normal `manage` invocation
+can't hit this. If you see it, please
+[file an issue](https://github.com/nivintw/ddns/issues) with the exact command you ran.
 
 **Cause:** internal code tried to manage or un-manage a subdomain whose top-level domain isn't
-marked as managed in the local database.
+marked as managed (`un-manage`) or managed at all (`manage`) in the local database.
 
 #### `NoManagedSubdomainsError`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,13 +5,14 @@ SPDX-License-Identifier: MIT
 
 # Troubleshooting
 
-If `do_ddns` exited with a red `Error:` message, find it below. Each entry leads with the fix.
+If `do_ddns` exited with an error, find the message it printed below. Each entry leads with
+the fix.
 
 !!! note
     Except for `show-info`, none of these errors are caught internally — the friendly message
-    below is followed by a full Python traceback. That traceback is expected; the line
-    starting with `Error:` (or the API key message for `NoAPIKeyError`) is the part that
-    matters.
+    shown in each entry below (the exact text varies per error; not all of them start with
+    `Error:`) is followed by a full Python traceback. That traceback is expected; the friendly
+    message above it is the part that matters.
 
 ## `NoAPIKeyError`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,7 +13,7 @@ If `do_ddns` exited with a red `Error:` message, find it below. Each entry leads
     starting with `Error:` (or the API key message for `NoAPIKeyError`) is the part that
     matters.
 
-#### `NoAPIKeyError`
+## `NoAPIKeyError`
 
 **Looks like:**
 
@@ -31,7 +31,7 @@ export DIGITALOCEAN_TOKEN=<your-do-token>
 environment — cron and systemd don't inherit your interactive shell) that `do_ddns` is running in.
 See [Configuration](configuration.md#api-token) for details.
 
-#### `NoIPResolverServerError`
+### `NoIPResolverServerError`
 
 **Looks like:**
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,14 +5,15 @@ SPDX-License-Identifier: MIT
 
 # Troubleshooting
 
-If `do_ddns` exited with an error, find the message it printed below. Each entry leads with
-the fix.
+If `do_ddns` exited with an error, find the message below. Each entry leads with the fix.
 
 !!! note
-    Except for `show-info`, none of these errors are caught internally — the friendly message
-    shown in each entry below (the exact text varies per error; not all of them start with
-    `Error:`) is followed by a full Python traceback. That traceback is expected; the friendly
-    message above it is the part that matters.
+    Except for `show-info`, none of these errors are caught internally, so you'll also see a
+    full Python traceback — that's expected. Most entries print a friendly line (shown below)
+    *before* the traceback; a couple (`NoIPResolverServerError`) print nothing separately and
+    the message below only appears as the traceback's final line
+    (`ip.NoIPResolverServerError: <message>`). Either way, the text shown in **Looks like**
+    below is what to search on.
 
 ## `NoAPIKeyError`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,113 @@
+<!--
+SPDX-FileCopyrightText: © 2023 Tyler Nivin
+SPDX-License-Identifier: MIT
+-->
+
+# Troubleshooting
+
+If `do_ddns` exited with a traceback or a red `Error:` message, find it below. Each entry leads
+with the fix.
+
+#### `NoAPIKeyError`
+
+**Looks like:**
+
+```text
+Error: Missing APIkey. Please set the DIGITALOCEAN_TOKEN environment variable!
+```
+
+**Fix:** export your DigitalOcean token before running any `do_ddns` command:
+
+```bash
+export DIGITALOCEAN_TOKEN=<your-do-token>
+```
+
+**Cause:** the `DIGITALOCEAN_TOKEN` environment variable isn't set in the shell (or scheduler
+environment — cron and systemd don't inherit your interactive shell) that `do_ddns` is running in.
+See [Configuration](configuration.md#api-token) for details.
+
+#### `NoIPResolverServerError`
+
+**Looks like:**
+
+```text
+Please configure an IP resolver server.
+```
+
+**Fix:** configure an IP resolver before running `update-ips` or `manage`:
+
+```bash
+do_ddns ip-resolver-config --url https://api.ipify.org
+```
+
+**Cause:** any command that needs to resolve your public IP address (`update-ips`, `manage`) needs
+an IP resolver configured first, and none has been set yet. See the
+[`ip-resolver-config` command reference](commands/ip-resolver-config.md).
+
+#### `TopDomainNotManagedError`
+
+**Looks like:**
+
+```text
+Error: example.com is not a managed domain. We do not expect users to ever be exposed to this
+error. If you see this in the console while using digital-ocean-dynamic-dns please open an issue
+on the repository.
+```
+
+**Fix:** this shouldn't happen through normal CLI use — `manage` and `un-manage` always ensure the
+top-level domain is managed before touching a subdomain. If you hit this, please
+[file an issue](https://github.com/nivintw/ddns/issues) with the command you ran; it points at a
+bug rather than something you did wrong.
+
+**Cause:** internal code tried to manage or un-manage a subdomain whose top-level domain isn't
+marked as managed in the local database.
+
+#### `NoManagedSubdomainsError`
+
+**Looks like:**
+
+```text
+Error: There are no dynamic domains active. Start by adding a new domain with do_ddns manage.
+E.g. do_ddns manage example.com --subdomain test.
+```
+
+**Fix:** manage at least one domain (or subdomain) before running `update-ips`:
+
+```bash
+do_ddns manage example.com --subdomain home
+```
+
+**Cause:** `update-ips` was run but zero subdomains are currently managed, so there's nothing to
+update. See the [`manage` command reference](commands/manage.md).
+
+#### `IPv6NotSupportedError`
+
+**Looks like:**
+
+```text
+IPv6 is not currently supported.
+```
+
+**Fix:** use `--ip-mode 4` (the default) instead:
+
+```bash
+do_ddns ip-resolver-config --url https://api.ipify.org --ip-mode 4
+```
+
+**Cause:** `ip-resolver-config --ip-mode 6` was used. IPv6 isn't supported yet — see the
+[roadmap](roadmap.md) for the current state of IPv6 support.
+
+#### `NonSimpleDomainNameError`
+
+**Looks like:**
+
+```text
+Error: Give the domain name in simple form e.g. test.domain.com
+```
+
+**Fix:** pass the plain ASCII form of the domain/subdomain name, e.g. `test.domain.com` rather
+than a fully-qualified trailing-dot form, an internationalized domain name, or anything with
+unexpected punctuation.
+
+**Cause:** the domain or subdomain name given to `manage`/`un-manage` contains characters outside
+ASCII letters, digits, `.`, `-`, and `@`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -65,7 +65,7 @@ domain `do_ddns` has never cataloged (a typo in the domain name, or a domain you
 [`manage`](commands/manage.md)d in the first place). Double-check the domain name, or run
 `do_ddns manage <domain>` first if you meant to catalog it.
 
-**From [`manage`](commands/manage.md) `--subdomain` (or `--list`):**
+**From [`manage`](commands/manage.md) (bare, or `--subdomain`):**
 
 ```text
 Error: example.com is not a managed domain. We do not expect users to ever be exposed to this

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,3 +127,16 @@ validation:
 
 nav:
   - Home: index.md
+  - Getting Started: getting-started.md
+  - Commands:
+      - Overview: commands/index.md
+      - update-ips: commands/update-ips.md
+      - manage: commands/manage.md
+      - un-manage: commands/un-manage.md
+      - ip-resolver-config: commands/ip-resolver-config.md
+      - show-info: commands/show-info.md
+      - logs: commands/logs.md
+  - Concepts: concepts.md
+  - Configuration: configuration.md
+  - Troubleshooting: troubleshooting.md
+  - Roadmap: roadmap.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,37 @@ theme:
         icon: material/brightness-7
         name: Switch to dark mode
 
+# Overrides Material's default `code { word-break: break-word }`, which otherwise breaks
+# long identifiers (e.g. `project_name`) mid-word inside narrow table columns — see
+# stylesheets/extra.css (scaffolded alongside this file) for the fix itself.
+extra_css:
+  - stylesheets/extra.css
+
+# Adding this key at all switches MkDocs off its implicit default plugin set (just
+# `search`), so `search` is listed explicitly below or built-in search silently
+# disappears (nivintw/repo-management#85 fleet epic; #94/#95/#97 for the other three).
+plugins:
+  - search
+  # Per-page "last updated" date derived from git history (nivintw/repo-management#94).
+  # Needs full git history to compute correct per-page dates — the reusable Pages build
+  # workflow already checks out with fetch-depth: 0 for this reason.
+  - git-revision-date-localized:
+      type: date
+  # Branded social-card (og:image) generation per page (nivintw/repo-management#95).
+  # Needs cairosvg + pillow, which need native cairo/freetype libs the reusable Pages
+  # build workflow already apt-installs — cairosvg's ctypes loader can't resolve
+  # Homebrew's libcairo on macOS, so this can only be verified on the Linux CI build, not
+  # a local `mkdocs build`.
+  - social
+  # Publishes an llms.txt (per https://llmstxt.org/) so LLM tooling can fetch the docs
+  # directly instead of scraping themed HTML (nivintw/repo-management#97). `sections`
+  # mirrors the nav placeholder below (just `Home: index.md`) — like nav, the real
+  # per-page listing is authored per repo by the generate-docs skill, not here.
+  - llmstxt:
+      sections:
+        Documentation:
+          - index.md
+
 # Fleet-general baseline only — each entry earns its place with real content it enables,
 # not just because Material supports it (no mermaid custom_fences here; pymdownx.emoji is
 # scoped to Material's own icon set, never a general emoji picker — see below).
@@ -95,6 +126,20 @@ markdown_extensions:
   # Lets Markdown syntax (bold, code spans, links) work *inside* a raw HTML block.
   - md_in_html
   - footnotes
+  # Shared content fragments (`--8<-- "install.md"`) so e.g. install instructions can't
+  # drift between the homepage and per-plugin pages (nivintw/repo-management#96,
+  # config-only). base_path is relative to docs/includes/ — a snippet reference is just
+  # the filename within that dir, not the full docs/includes/... path.
+  - pymdownx.snippets:
+      base_path: docs/includes
+      check_paths: true
+  # Auto-links bare `owner/repo#N` issue/PR references and commit SHAs
+  # (nivintw/repo-management#96, config-only).
+  - pymdownx.magiclink:
+      repo_url_shortener: true
+      repo_url_shorthand: true
+      user: "nivintw"
+      repo: "ddns"
 
 # docs/superpowers/** holds dev-only brainstorming specs and plans (the
 # superpowers:brainstorming/writing-plans convention) — shares the docs/ tree with the
@@ -110,6 +155,7 @@ markdown_extensions:
 # real build was tried (nivintw/copier-everything#157).
 exclude_docs: |
   superpowers/
+  includes/
 
 # MkDocs 1.5+'s own validation checks, made explicit rather than left to its undocumented
 # defaults — `warn` is what `--strict` (this fleet's `generate-docs` Stage 4 always builds

--- a/src/digital_ocean_dynamic_dns/subdomains.py
+++ b/src/digital_ocean_dynamic_dns/subdomains.py
@@ -305,11 +305,11 @@ def update_all_managed_subdomains(args: Namespace) -> None:
         console.print(
             "[red]Error: [/red]There are no dynamic domains active."
             " Start by adding a new domain with [i]do_ddns manage[/i]."
-            " E.g. [i]do_ddns manage example.com --sub-domain test[/i]."
+            " E.g. [i]do_ddns manage example.com --subdomain test[/i]."
         )
         msg = (
             "There are no active dynamic domains. "
-            "Add one with: do_ddns manage example.com --sub-domain test"
+            "Add one with: do_ddns manage example.com --subdomain test"
         )
         raise NoManagedSubdomainsError(msg)
 


### PR DESCRIPTION
<!-- rumdl-disable-file MD041 -->

## What

Authors the digital-ocean-dynamic-dns docs site from scratch (issue #30): a Getting Started
guide, a full 6-command reference, a Concepts page formalizing the domain/subdomain
vocabulary, Configuration, Troubleshooting, and Roadmap pages. README/CONTRIBUTING.md are
reconciled to link out to the new site instead of duplicating its content. Also includes a
small, separately-approved bugfix (see below).

## Why

Closes part of #30 — the docs-content-authored and site-builds-clean acceptance criteria.
GitHub Pages enablement (a cross-repo change in `nivintw/repo-management`) is explicitly out
of scope for this PR — that criterion stays open on #30.

## Verification

- [x] `mkdocs build --strict` clean
- [x] `check_docs.py` clean (no broken links/anchors, nav complete)
- [x] Playwright smoke check: pages load, content tabs swap correctly, light/dark theme
      toggle works, zero console errors across the session
- [x] Full review battery: workflow-backed code-review (clean), comment-analyzer, and two
      independent doc-accuracy verification passes that re-derived every documented flag,
      default, and behavior claim directly from source rather than trusting the authoring
      pass — found and fixed one real inaccuracy (see below)
- [x] `uvx prek@0.4.8 run --all-files` green
- [x] Full test suite: 108 passed, 95.67% coverage

## Included bugfix (separately approved, its own commit)

While researching command behavior for the docs, found that `NoManagedSubdomainsError`'s
remediation message suggested `--sub-domain`, which isn't a real flag (the actual flag is
`--subdomain`). Fixed as `df01bef`, called out here so it's not mistaken for a docs-only PR.

## Decisions made without asking

- **remove/register/deregister vocabulary**: documented as current-vs-planned (no CLI command
  implements them today) rather than omitted — your explicit choice.
- **README's stale "Planned Updates" checklist**: reconciled against actual current repo
  state (several items were already done, one superseded by a different tool than
  originally planned) rather than copied verbatim into `docs/roadmap.md`.
- **Review found `docs/troubleshooting.md`'s `TopDomainNotManagedError` entry was wrong**:
  it claimed this "shouldn't happen through normal use, file a bug" for all cases, but
  `un-manage --subdomain` against a domain that was never `manage`d hits this through
  ordinary user error (verified: `martial_un_manage` never pre-checks the domain is managed,
  unlike `martial_manage`). Split the entry into its two actual code paths with accurate
  guidance for each.
- **rumdl/mkdocs anchor-slugification disagreement**: one heading used an em-dash, which
  mkdocs Material's slugifier and rumdl's MD051 checker handle differently — rumdl flagged
  an mkdocs-correct link as broken. Fixed by rewording the heading to avoid the em-dash
  (both tools agree on a colon) rather than suppressing the check.
- **Cross-page/same-page duplication** (found by `/simplify`): collapsed restated-in-callout
  duplication on `manage.md`/`show-info.md`, and made `configuration.md`/`ip-resolver-config.md`
  the canonical owners of a couple of facts `getting-started.md` was restating in full.
- **PyPI-publishing content placement**: initially moved from README to a new CONTRIBUTING.md
  section in response to a Copilot review comment, without checking where the template
  actually puts it. Reverted — the `copier-everything` template's `README.md.jinja` canonically
  places this content in README (right before License), so moving it to CONTRIBUTING.md would
  just re-diverge on the next `copier update`. Kept in README, with the reworded/
  non-overclaiming phrasing from the original fix.

## Also updates the copier-everything template to v1.11.0

While this PR was in flight, `nivintw/copier-everything` released v1.11.0 (wires the fleet
docs-site feature set: search/git-revision-date/social-card/llmstxt plugins,
`pymdownx.snippets`/`pymdownx.magiclink`). Ran `copier update` to pick it up — clean, no
conflicts. Adopted the new `docs/includes/install.md` snippet mechanism for real: install
instructions now live once and are spliced into `getting-started.md` via
`pymdownx.snippets`, rather than only being *avoided* from README via a cross-link (the
duplication fix Copilot's review asked for, done the way the template now actually supports).

**Caveat**: the new `social` plugin (og:image generation) needs `cairosvg`, which can't load
`libcairo` via `ctypes` on macOS — a limitation the template's own comments already document
and expect (verified: Homebrew's cairo is installed, `DYLD_FALLBACK_LIBRARY_PATH` doesn't fix
it either — this is a known cairosvg/macOS papercut). Verified everything else builds clean
locally; `docs.yml` only triggers on push to `main` (not on PRs), so the social/git-revision-
date/llmstxt plugins won't actually be exercised by any CI check until this merges and the
Pages build runs for real on Linux (which does `apt install` the native cairo/freetype libs).

Refs #30 (this PR only addresses the docs-content-authored and site-builds-clean acceptance criteria — Pages enablement is separate, cross-repo work; the issue stays open).

