### PR TITLE
chore: update copier-everything template to v1.11.1

### DIFF
--- a/.config/rumdl.toml
+++ b/.config/rumdl.toml
@@ -26,7 +26,12 @@ style = "fenced"
 # parser mistakes that indentation ahead of an already-fenced block for a raw indented
 # code block, then "fixes" it by wrapping the tab's prose in stray fences too, destroying
 # the tab structure (see nivintw/copier-everything#178).
-"docs/*.md" = ["MD033", "MD046"]
+# `**` (not just `docs/*.md`) so this reaches a nested reference page (e.g.
+# docs/config/*.md) too — verified against the pinned rumdl version (v0.2.17): `*` alone
+# already crosses `/` in its glob engine (so `docs/*.md` was never actually broken for
+# nested files), but `**` is the version that stays correct if a future rumdl release
+# tightens that matching to the more common glob convention.
+"docs/**/*.md" = ["MD033", "MD046"]
 # MD041 (first line must be a level-1 heading): a pymdownx.snippets fragment isn't a
 # standalone page — it's spliced into whatever page includes it via `--8<--`, so forcing
 # an H1 here would inject a duplicate/wrong-level heading wherever it's included.

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY.
-_commit: v1.11.0
+_commit: v1.11.1
 _src_path: gh:nivintw/copier-everything
 author_email: tyler@nivin.tech
 author_name: Tyler Nivin

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,10 @@ name: docs
 on:
   push:
     branches: [main]
-    paths: ['docs/**', 'mkdocs.yml']
+    # overrides/** is the theme-customization dir this same include_docs_site feature
+    # scaffolds (overrides/404.html) — a change there alone (the 404 page, or any future
+    # theme override) must trigger a redeploy too, or the live site silently goes stale.
+    paths: ['docs/**', 'mkdocs.yml', 'overrides/**']
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/label-hygiene.yml
+++ b/.github/workflows/label-hygiene.yml
@@ -16,9 +16,9 @@
 # clean no-op — nothing gates the file, and there's nothing to error on. type:* / priority:*
 # are left intact as a historical record. Reopen is deliberately left to manual triage: we
 # act on `closed` only, so a reopened issue isn't silently shoved back to a status — the
-# step itself also re-checks the issue is STILL closed before stripping (see below), so a
-# reopen racing between the `closed` event and this run executing doesn't strip a live
-# issue's progression label.
+# step itself also re-checks the issue is STILL closed twice (see below): once after the
+# initial fetch, and again immediately before the label-removal edit, so a reopen racing
+# either window doesn't strip a live issue's progression label.
 
 name: label-hygiene
 
@@ -94,4 +94,13 @@ jobs:
             echo "Removing '$label' from issue #$ISSUE"
             args+=(--remove-label "$label")
           done <<<"$matched"
+          # Re-check once more, immediately before the mutating call: the check above closes
+          # the window between the `closed` event firing and the initial `gh issue view`, but
+          # a reopen landing in the (small, but nonzero) window between that view and this
+          # edit would otherwise still strip a label from what is now a live, open issue.
+          current_state="$(gh issue view "$ISSUE" --repo "$REPO" --json state --jq '.state')"
+          if [ "$current_state" != "CLOSED" ]; then
+            echo "Issue #$ISSUE is no longer closed (state: $current_state) — a reopen raced this run; skipping."
+            exit 0
+          fi
           gh issue edit "$ISSUE" --repo "$REPO" "${args[@]}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,28 +171,24 @@ jobs:
           # (auth, API 5xx) abort the step loudly instead of silently reading as "none found".
           # --limit raised well past gh's 30-item default so a busier repo's stranded PR can't
           # fall off the first page.
-          # commits is fetched here (not a separate gh pr view per candidate below) so the
-          # non-bot-commit check has no extra API round trip per stranded PR. gh caps this
-          # at the first 100 commits per PR — irrelevant in practice, since a release-please
-          # Release PR carries one generated bump commit (plus, rarely, a handful of manual
-          # fixups), nowhere near that limit.
+          #
+          # `commits` is deliberately NOT requested here: GitHub's GraphQL backend charges a
+          # node budget for every nested connection a query traverses (PR -> commits ->
+          # authors), and at --limit 100 that blows straight through the 500,000-node ceiling
+          # ("By the time this query traverses to the authors connection, it is requesting up
+          # to 1,000,000 possible nodes") — reproduced live against this exact repo/query, not
+          # a theoretical concern. Fetching commits per stranded candidate below instead costs
+          # at most a handful of extra API calls, since a repo normally has 0-1 stranded
+          # Release PRs open at any time.
           prs_json="$(gh pr list --state open --limit 100 \
-            --json number,author,labels,mergeStateStatus,commits)"
+            --json number,author,labels,mergeStateStatus)"
           # Same reasoning as above: a plain assignment (not `mapfile < <(...)`) so a jq
           # failure trips `set -e` too, instead of silently reading as "none found". An empty
           # filter result is a legitimate zero-matches outcome, not a failure — `mapfile` from
           # an empty string yields a one-element array holding "", so that case is normalized
-          # back to a true zero-length array below. Each stranded candidate's non-bot commit
-          # logins (if any) are computed here too and carried alongside the number as a TSV
-          # pair, rather than re-fetched per PR in the loop below.
-          # A commit author with no linked GitHub account (an unlinked git email) comes
-          # back with a null OR empty-string `.login` — falling straight to `.login` and
-          # joining would silently collapse a real human commit to an empty string (jq's
-          # `//` treats "" as truthy, so a bare `.login // .email` wouldn't fall through
-          # for that case either), defeating this whole check. Explicitly treat both null
-          # and "" as "no login" before falling back to `.email`/`.name`.
+          # back to a true zero-length array below.
           stranded_str="$(printf '%s' "$prs_json" | jq -r --arg app "${CI_APP_SLUG}[bot]" \
-            '.[] | select(.author.login == $app and (.labels[]?.name == "autorelease: pending") and .mergeStateStatus == "DIRTY") | [.number, ([.commits[].authors[]? | select(.login != $app) | ((.login | select(. != null and . != "")) // .email // .name // "unknown-author")] | unique | join(", "))] | @tsv')"
+            '.[] | select(.author.login == $app and (.labels[]?.name == "autorelease: pending") and .mergeStateStatus == "DIRTY") | .number')"
           stranded=()
           if [ -n "$stranded_str" ]; then
             mapfile -t stranded <<<"$stranded_str"
@@ -201,15 +197,23 @@ jobs:
             echo "No stranded Release PRs found."
             exit 0
           fi
-          for entry in "${stranded[@]}"; do
+          for num in "${stranded[@]}"; do
             # Never auto-close a stranded PR carrying a human's manual commit: the PR's
             # author field is immutable (release-please's bot login), so a maintainer's
             # fixup pushed directly onto the bot's branch still matches the filter above —
             # closing it under the "release-please will regenerate this PR" message would
-            # silently discard those commits, not just an auto-generated bump. Checked above
+            # silently discard those commits, not just an auto-generated bump. Checked here
             # from the branch's actual commits (a persistent record, unlike the mutable
             # `author` field) rather than trusting the PR-level author.
-            IFS=$'\t' read -r num non_bot_logins <<<"$entry"
+            #
+            # A commit author with no linked GitHub account (an unlinked git email) comes
+            # back with a null OR empty-string `.login`/`.email` — falling straight through
+            # `//` would silently collapse a real human commit to an empty string (jq's `//`
+            # treats "" as truthy, so a bare `.login // .email // .name` wouldn't fall through
+            # for either field), defeating this whole check. Explicitly treat both null and ""
+            # as "absent" at every step of the fallback chain, not just the first one.
+            non_bot_logins="$(gh pr view "$num" --json commits | jq -r --arg app "${CI_APP_SLUG}[bot]" \
+              '[.commits[].authors[]? | select(.login != $app) | ((.login | select(. != null and . != "")) // (.email | select(. != null and . != "")) // .name // "unknown-author")] | unique | join(", ")')"
             if [ -n "$non_bot_logins" ]; then
               echo "::warning::Release PR #${num} is DIRTY but carries a commit from ${non_bot_logins} (not just ${CI_APP_SLUG}[bot]) — leaving it open rather than auto-closing, since that would discard those commits. Resolve the conflict manually."
               continue

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,7 +152,10 @@ jobs:
       # (no-op) if the variable isn't set, same as that workflow. The label check is literal
       # equality against DIRTY (not "!= CLEAN"): mergeStateStatus is transiently UNKNOWN right
       # after a push, so a just-orphaned PR simply isn't caught this run and converges on a
-      # later one instead of being misclassified.
+      # later one instead of being misclassified. This filter only narrows the CANDIDATE set
+      # to close, though — a maintainer's manual fixup commit pushed onto the bot's branch
+      # doesn't change the PR's (immutable) author field, so the step itself re-checks each
+      # candidate's actual commits before closing (see below) rather than trusting this alone.
       - name: Close any stranded (DIRTY) Release PRs so release-please regenerates them
         if: vars.CI_APP_SLUG != ''
         env:
@@ -168,15 +171,28 @@ jobs:
           # (auth, API 5xx) abort the step loudly instead of silently reading as "none found".
           # --limit raised well past gh's 30-item default so a busier repo's stranded PR can't
           # fall off the first page.
+          # commits is fetched here (not a separate gh pr view per candidate below) so the
+          # non-bot-commit check has no extra API round trip per stranded PR. gh caps this
+          # at the first 100 commits per PR — irrelevant in practice, since a release-please
+          # Release PR carries one generated bump commit (plus, rarely, a handful of manual
+          # fixups), nowhere near that limit.
           prs_json="$(gh pr list --state open --limit 100 \
-            --json number,author,labels,mergeStateStatus)"
+            --json number,author,labels,mergeStateStatus,commits)"
           # Same reasoning as above: a plain assignment (not `mapfile < <(...)`) so a jq
           # failure trips `set -e` too, instead of silently reading as "none found". An empty
           # filter result is a legitimate zero-matches outcome, not a failure — `mapfile` from
           # an empty string yields a one-element array holding "", so that case is normalized
-          # back to a true zero-length array below.
-          stranded_str="$(printf '%s' "$prs_json" | jq --arg app "${CI_APP_SLUG}[bot]" \
-            '.[] | select(.author.login == $app and (.labels[]?.name == "autorelease: pending") and .mergeStateStatus == "DIRTY") | .number')"
+          # back to a true zero-length array below. Each stranded candidate's non-bot commit
+          # logins (if any) are computed here too and carried alongside the number as a TSV
+          # pair, rather than re-fetched per PR in the loop below.
+          # A commit author with no linked GitHub account (an unlinked git email) comes
+          # back with a null OR empty-string `.login` — falling straight to `.login` and
+          # joining would silently collapse a real human commit to an empty string (jq's
+          # `//` treats "" as truthy, so a bare `.login // .email` wouldn't fall through
+          # for that case either), defeating this whole check. Explicitly treat both null
+          # and "" as "no login" before falling back to `.email`/`.name`.
+          stranded_str="$(printf '%s' "$prs_json" | jq -r --arg app "${CI_APP_SLUG}[bot]" \
+            '.[] | select(.author.login == $app and (.labels[]?.name == "autorelease: pending") and .mergeStateStatus == "DIRTY") | [.number, ([.commits[].authors[]? | select(.login != $app) | ((.login | select(. != null and . != "")) // .email // .name // "unknown-author")] | unique | join(", "))] | @tsv')"
           stranded=()
           if [ -n "$stranded_str" ]; then
             mapfile -t stranded <<<"$stranded_str"
@@ -185,7 +201,19 @@ jobs:
             echo "No stranded Release PRs found."
             exit 0
           fi
-          for num in "${stranded[@]}"; do
+          for entry in "${stranded[@]}"; do
+            # Never auto-close a stranded PR carrying a human's manual commit: the PR's
+            # author field is immutable (release-please's bot login), so a maintainer's
+            # fixup pushed directly onto the bot's branch still matches the filter above —
+            # closing it under the "release-please will regenerate this PR" message would
+            # silently discard those commits, not just an auto-generated bump. Checked above
+            # from the branch's actual commits (a persistent record, unlike the mutable
+            # `author` field) rather than trusting the PR-level author.
+            IFS=$'\t' read -r num non_bot_logins <<<"$entry"
+            if [ -n "$non_bot_logins" ]; then
+              echo "::warning::Release PR #${num} is DIRTY but carries a commit from ${non_bot_logins} (not just ${CI_APP_SLUG}[bot]) — leaving it open rather than auto-closing, since that would discard those commits. Resolve the conflict manually."
+              continue
+            fi
             echo "Closing stranded Release PR #${num} (DIRTY against current main)."
             # Tolerate ONLY the expected race (someone/something else already closed or
             # merged it between the list above and this close) so one benign race doesn't

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,14 @@ theme:
 extra_css:
   - stylesheets/extra.css
 
+# The asciinema-player extra_css/extra_javascript wiring the template unconditionally
+# re-added in v1.11.1 (restoring nivintw/copier-everything#196) is left out here: ddns has
+# no embedded `.cast` recordings, and those tags 404 on every page load until a repo
+# vendors docs/assets/asciinema-player.{css,min.js} — the exact regression of
+# nivintw/copier-everything#172 (already fixed once, filed again as #206). Per
+# generate-docs's SKILL.md convention, add both lines back only when this repo embeds its
+# first cast.
+
 # Adding this key at all switches MkDocs off its implicit default plugin set (just
 # `search`), so `search` is listed explicitly below or built-in search silently
 # disappears (nivintw/repo-management#85 fleet epic; #94/#95/#97 for the other three).

--- a/scripts/refresh-binary-checksums.sh
+++ b/scripts/refresh-binary-checksums.sh
@@ -106,35 +106,69 @@ cached_sha() { # <TOOL> <version> <outvar>
   printf -v "$3" '%s' "${SHA_CACHE[$key]}"
 }
 
-# Extract the quoted value of an env-var assignment (first occurrence). Empty (exit 0) when absent.
-pinned_value() { # <VAR> <file> -> value or empty
-  # Fail loudly on a bad path instead of masking it as "no pin found": grep's own exit code
-  # conflates "no match" (1 — the intended empty-return case) with "read error" (>=2, e.g. a
-  # missing or unreadable file). The guard below catches a missing file up front; capturing
-  # grep's own exit code (not the head/sed pipeline's, which would swallow it) catches any
-  # other read failure the guard doesn't, e.g. a file that exists but isn't readable.
-  [ -f "$2" ] || {
-    echo "ERROR: pinned_value: no such file: $2" >&2
-    exit 1
-  }
-  # Anchored to (whitespace-then-)line-start so a search for TRIVY_VERSION can't match inside
-  # a hypothetical OLD_TRIVY_VERSION — a bare \b wouldn't help here since `_` is a word char.
+# Shared tail for pinned_value()/pinned_value_at_base(): extract the quoted value of an
+# env-var assignment (first occurrence) from content on stdin. <caller>/<location> are
+# only for the error message, so the two callers keep their own distinct wording.
+# Anchored to (whitespace-then-)line-start so a search for TRIVY_VERSION can't match inside
+# a hypothetical OLD_TRIVY_VERSION — a bare \b wouldn't help here since `_` is a word char.
+_extract_pinned_value() { # <VAR> <caller> <location> -> value or empty (reads stdin)
   local matched grep_rc
-  matched="$(grep -oE "^[[:space:]]*$1: \"[^\"]+\"" "$2")" && grep_rc=0 || grep_rc=$?
+  matched="$(grep -oE "^[[:space:]]*$1: \"[^\"]+\"")" && grep_rc=0 || grep_rc=$?
   if [ "$grep_rc" -gt 1 ]; then
-    echo "ERROR: pinned_value: grep failed reading $2 (exit $grep_rc)" >&2
+    echo "ERROR: $2: grep failed reading $3 (exit $grep_rc)" >&2
     exit 1
   fi
   printf '%s\n' "$matched" | head -n1 | sed -E 's/.*"([^"]+)".*/\1/'
 }
+
+pinned_value() { # <VAR> <file> -> value or empty
+  # Fail loudly on a bad path instead of masking it as "no pin found": the guard below
+  # catches a missing file up front; reading it via `cat` under `set -e` catches any other
+  # read failure (e.g. a file that exists but isn't readable) by aborting the assignment.
+  # _extract_pinned_value() separately guards grep's own exit code against the piped
+  # content (conflating "no match" — the intended empty-return case — with a real read
+  # error would be the same class of bug this whole file exists to avoid).
+  [ -f "$2" ] || {
+    echo "ERROR: pinned_value: no such file: $2" >&2
+    exit 1
+  }
+  # Read into a variable rather than redirecting "$2" as stdin on the same line it's also
+  # passed as an argument — shellcheck's SC2094 (read-and-write-same-file) fires on that
+  # syntactic shape even though nothing here is written, only read.
+  local content
+  content="$(cat "$2")"
+  printf '%s' "$content" | _extract_pinned_value "$1" pinned_value "$2"
+}
 pinned_value_at_base() { # <VAR> <file> <baseref> -> value at base or empty
-  # A path absent at BASE_REF (introduced since) is the one legitimate empty case here —
-  # check for it explicitly with git cat-file -e, rather than folding it into a blanket
-  # "swallow any git show failure," which would also mask a genuine read error (corrupted
-  # object, partial-clone missing blob) as an empty base_version — feeding the same tamper
-  # gate pinned_value()'s guard above protects for the plain-file case.
-  git cat-file -e "$3:$2" 2>/dev/null || return 0
-  git show "$3:$2" | grep -oE "^[[:space:]]*$1: \"[^\"]+\"" | head -n1 | sed -E 's/.*"([^"]+)".*/\1/' || true
+  # A path absent at BASE_REF (introduced since) is the one legitimate empty case here.
+  # `git cat-file -e`'s exit code alone can't distinguish it from a genuine read error
+  # (corrupted object, partial-clone missing blob): a missing path exits 128 with a "does
+  # not exist"/"exists on disk, but not in" message (git picks the wording based on whether
+  # the path is also absent from the *working tree* — every real caller here passes a file
+  # that IS on disk, per the `[ -f "$f" ]` guard above, so the "exists on disk" wording is
+  # actually the common case, not the exotic one), but a missing blob exits 1 with no
+  # message at all — so match cat-file's own message instead of trusting the exit code, and
+  # fail loudly on anything else, the same tamper gate pinned_value()'s guard above protects
+  # for the plain-file case. LC_ALL=C pins the message to English regardless of the runner's
+  # locale — git's fatal messages are translated, and matching translated text would silently
+  # break this exact legitimate case on a non-English runner.
+  local cat_err
+  if ! cat_err="$(LC_ALL=C git cat-file -e "$3:$2" 2>&1 1>/dev/null)"; then
+    case "$cat_err" in
+    *"does not exist in"* | *"exists on disk, but not in"*) return 0 ;;
+    esac
+    echo "ERROR: pinned_value_at_base: git cat-file -e $3:$2 failed: ${cat_err:-(no output)}" >&2
+    exit 1
+  fi
+  # Real exit-status check on git show — mirroring pinned_value()'s grep-exit-code guard
+  # above — so a genuine failure here isn't swallowed as "no pin found" the way a trailing
+  # `|| true` on the whole pipeline would.
+  local blob
+  if ! blob="$(git show "$3:$2")"; then
+    echo "ERROR: pinned_value_at_base: git show $3:$2 failed" >&2
+    exit 1
+  fi
+  printf '%s\n' "$blob" | _extract_pinned_value "$1" pinned_value_at_base "$3:$2"
 }
 
 if [ "$#" -gt 0 ]; then


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2023 Tyler Nivin
SPDX-License-Identifier: MIT
-->

## What

Updates the copier-everything scaffold template from v1.11.0 to v1.11.1
(`copier update --trust --skip-tasks --defaults --vcs-ref v1.11.1 .`), plus one
local override and one local bugfix on top of the raw template output.

Closes #43

## Why

Keep the scaffold current. v1.11.1's release notes cover: docs-site push
trigger watching `overrides/**`, `pinned_value_at_base()` hardening, a
non-bot-commit guard for the stranded-Release-PR closer, restored
asciinema-player mkdocs wiring, a widened rumdl per-file-ignores glob, and a
label-hygiene TOCTOU re-check.

## Decisions made without asking

- **Removed the `extra_css`/`extra_javascript` asciinema-player wiring**
  v1.11.1 unconditionally re-added to `mkdocs.yml` (restoring
  [nivintw/copier-everything#196](https://github.com/nivintw/copier-everything/issues/196)).
  This regresses the already-fixed
  [nivintw/copier-everything#172](https://github.com/nivintw/copier-everything/issues/172) —
  the tags 404 on every page load since no template task vendors the actual asset
  files, confirmed by building the site and finding zero "asciinema" references in
  the output. ddns has no embedded `.cast` recordings. Filed
  [nivintw/copier-everything#206](https://github.com/nivintw/copier-everything/issues/206)
  upstream to reconcile #172 vs #196 properly; worked around locally per
  `generate-docs`'s own convention (add the two lines back only when this repo
  embeds its first cast).
- **Fixed a critical bug in the incoming template's stranded-Release-PR closer**
  (`.github/workflows/main.yml`) rather than shipping it as generated: the new
  non-bot-commit guard (added by
  [nivintw/copier-everything#195](https://github.com/nivintw/copier-everything/issues/195))
  bundles `commits` into the bulk `gh pr list --limit 100` query, which blows
  GitHub's GraphQL node-budget ceiling — reproduced live against this repo
  (`...requesting up to 1,000,000 possible nodes which exceeds the maximum limit
  of 500,000`). That means the step would fail on essentially every run once
  `CI_APP_SLUG` is set, not just in some edge case. The same guard's jq fallback
  chain also guards `.login` against null/empty-string but not `.email`, leaving
  the exact #195 failure mode open for an unlinked/empty-string author email.
  Fixed locally (split the query so `commits` is fetched per-DIRTY-candidate via
  `gh pr view` instead, and extended the null/"" guard to `.email`); verified
  end-to-end against this repo's real PR history. Filed upstream as
  [nivintw/copier-everything#207](https://github.com/nivintw/copier-everything/issues/207).
- Everything else in the `copier update` diff (rumdl glob widening, docs.yml
  `overrides/**` trigger, label-hygiene TOCTOU re-check,
  `pinned_value_at_base()` hardening) was accepted as-is from the template.

## Verification

- [x] The quality gate passes (`prek run --all-files` — all hooks green)
- `uv run pytest -q`: 108 passed, 95.67% coverage
- `mkdocs build --strict`: builds clean, 0 warnings, using an ephemeral env
  mirroring the reusable docs workflow's exact pins
- `scripts/refresh-binary-checksums.sh`: all checksums current
- Confirmed `overrides/404.html` exists so the new `docs.yml` trigger path is real
- The fixed stranded-Release-PR-closer step verified end-to-end against real
  open/closed PRs in this repo (bot-only PR correctly classified as closeable;
  human-authored PR correctly classified as non-bot)
- 5-agent review battery (code-review, silent-failure-hunter, comment-analyzer,
  security, adversarial) run against the diff — see decisions above for what it
  surfaced; one low-severity/informational security note (log-injection via
  commit-author text, requires pre-existing write access) accepted as-is,
  template-owned
