### PR TITLE
chore: update copier-everything template to v1.12.0

### DIFF
--- a/.claude/hooks/_hooklib.py
+++ b/.claude/hooks/_hooklib.py
@@ -1,0 +1,128 @@
+"""Shared helpers for the PreToolUse guard hooks (Claude Code hook contract).
+
+Each guard is a standalone module: importable (its functions unit-tested directly, no
+`__main__` side effects) and runnable as a `command` hook that reads the PreToolUse JSON
+event on stdin and decides allow / deny / fail-open-loud. This module is the thin, shared
+I/O + path-resolution layer so the three guards stay consistent.
+
+Portability note: Claude Code runs these via whatever `python3` is on PATH, which may be
+older than the project's own interpreter, so the hooks target Python 3.9+ (verified running
+under 3.9). Two things that would otherwise break that: `except (...)` tuples stay
+PARENTHESIZED (Python 3.14's PEP 758 made the parens optional, but < 3.14 still requires
+them); and every PEP 604 `X | Y` union appears ONLY in a type annotation, which
+`from __future__ import annotations` (PEP 563) keeps as an unevaluated string — so it never
+hits the runtime `types.UnionType` machinery that needs 3.10+ (the only runtime `|` here is a
+plain set union, valid everywhere).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Tools that write to a file — the only ones any of these guards act on.
+FILE_WRITE_TOOLS = frozenset({"Edit", "Write", "MultiEdit"})
+
+
+def read_event() -> dict:
+    """Parse the PreToolUse JSON event from stdin; an empty/invalid payload → {}."""
+    try:
+        return json.loads(sys.stdin.read() or "{}")
+    except (json.JSONDecodeError, ValueError):
+        return {}
+
+
+def edited_path(event: dict) -> str | None:
+    """The absolute file_path an Edit/Write/MultiEdit targets, else None (not a file write)."""
+    if event.get("tool_name") not in FILE_WRITE_TOOLS:
+        return None
+    return (event.get("tool_input") or {}).get("file_path")
+
+
+def project_root(start: Path) -> Path | None:
+    """The nearest ancestor of `start` (inclusive) containing a `.git`, else None.
+
+    Root-anchoring on the edited file's own repo — not the session cwd — is what makes the
+    guards copier-path aware: an edit to a path inside a generated project resolves its managed
+    set against that project's root even when Claude's cwd is elsewhere.
+    """
+    for directory in (start, *start.parents):
+        if (directory / ".git").exists():
+            return directory
+    return None
+
+
+def resulting_content(event: dict, file: Path) -> str | None:
+    """The file's content AFTER the pending edit, or None if it can't be reconstructed.
+
+    Write carries the whole `content`; Edit/MultiEdit are applied to the current on-disk file
+    the same way Claude Code will apply them (first-occurrence replace, or all when replace_all).
+    """
+    tool_input = event.get("tool_input") or {}
+    if "content" in tool_input:  # Write
+        return tool_input["content"]
+    try:
+        current = file.read_text()
+    except OSError:
+        return None
+    if "new_string" in tool_input:  # Edit
+        old, new = tool_input.get("old_string", ""), tool_input["new_string"]
+        return (
+            current.replace(old, new)
+            if tool_input.get("replace_all")
+            else current.replace(old, new, 1)
+        )
+    if "edits" in tool_input:  # MultiEdit
+        for edit in tool_input["edits"]:
+            old, new = edit.get("old_string", ""), edit.get("new_string", "")
+            current = (
+                current.replace(old, new)
+                if edit.get("replace_all")
+                else current.replace(old, new, 1)
+            )
+        return current
+    return None
+
+
+def allow() -> None:
+    """Permit the tool call (no output is the default-allow contract)."""
+    sys.exit(0)
+
+
+def deny(reason: str) -> None:
+    """Block the tool call, surfacing `reason` to Claude."""
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            }
+        )
+    )
+    sys.exit(0)
+
+
+def warn_allow(message: str) -> None:
+    """Fail OPEN but loudly: permit the call while surfacing a warning — never silently allow.
+
+    Used when a guard can't establish the fact it needs to make a safe decision (e.g. the
+    canonical version can't be resolved). Blocking on uncertainty would trap legitimate work;
+    a silent allow would defeat the guard — so allow, but say so.
+    """
+    print(json.dumps({"systemMessage": message}))
+    print(message, file=sys.stderr)
+    sys.exit(0)
+
+
+def dispatch(action: str, message: str) -> None:
+    """Carry out the decision a guard's `decide()` returned — the shared tail of every main()."""
+    if action == "deny":
+        deny(message)
+    elif action == "warn_allow":
+        warn_allow(message)
+    else:
+        allow()

--- a/.claude/hooks/guard_config_drift.py
+++ b/.claude/hooks/guard_config_drift.py
@@ -1,0 +1,147 @@
+"""PreToolUse guard: warn on twin drift, and block language-agnostic config in pyproject.toml.
+
+Two edit-time guards:
+
+1. Twin-drift WARNING (own dogfood repo only). copier-everything keeps certain files as both a
+   templated source under `template/` and a rendered copy at the repo root — "twins" that must
+   stay in sync (tests/test_synced_files.py detects drift in CI; scripts/resync_twins.py fixes
+   it). This warns, at edit time, when you touch one side, naming its partner — the preventive
+   counterpart. It only fires when a `template/` dir exists, so a generated project (no template)
+   never sees it.
+
+2. Ban language-agnostic config in pyproject.toml (BLOCK, everywhere). Python is optional here,
+   so `pyproject.toml` only exists for Python projects; config that isn't Python-specific must
+   live in its language-neutral home under `.config/` instead. Writing one of those tables into
+   pyproject.toml is blocked, pointing at the right file.
+
+The WATCHED twin set and the banned-table list are derived from copier-everything's OWN layout
+(tests/test_guard_config_drift.py verifies WATCHED against test_synced_files' buckets), not
+copied from any downstream.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# _hooklib is the sibling module on sys.path (script dir when run, harness-inserted when imported).
+from _hooklib import (
+    dispatch,
+    edited_path,
+    project_root,
+    read_event,
+    resulting_content,
+)
+
+# Files kept in sync between the repo root and their `template/` source — copier-everything's own
+# twin set (tests/test_synced_files.py::TRIVIALLY_EQUAL ∪ STRUCTURALLY_TESTED). A guard test
+# asserts this stays equal to those buckets so the two can't silently drift apart.
+WATCHED: frozenset[str] = frozenset(
+    {
+        ".config/rumdl.toml",
+        ".config/yamllint.yaml",
+        ".config/lychee.toml",
+        ".github/workflows/approve-bot-prs.yml",
+        ".github/workflows/label-hygiene.yml",
+        ".github/workflows/pr.yml",
+        ".github/workflows/link-check.yml",
+        ".github/workflows/docs.yml",
+        "LICENSE",
+        "LICENSES/MIT.txt",
+        "docs/assets/favicon.svg",
+        "docs/stylesheets/extra.css",
+        "overrides/404.html",
+        "pyproject.toml",
+        ".cz.toml",
+        ".vscode/settings.json",
+        ".vscode/extensions.json",
+        ".editorconfig",
+        "scripts/refresh-binary-checksums.sh",
+        "mkdocs.yml",
+        ".claude/settings.json",
+        ".claude/hooks/_hooklib.py",
+        ".claude/hooks/guard_version_bumps.py",
+        ".claude/hooks/guard_managed_files.py",
+        ".claude/hooks/guard_config_drift.py",
+    }
+)
+
+# Language-agnostic tools the template deliberately configures OUTSIDE pyproject.toml (under
+# .config/, because Python is optional). Each maps its pyproject table name → its real home.
+BANNED_PYPROJECT_TABLES: dict[str, str] = {
+    "typos": ".config/typos.toml",
+    "rumdl": ".config/rumdl.toml",
+    "lychee": ".config/lychee.toml",
+    "yamllint": ".config/yamllint.yaml",
+}
+
+
+def _twin_partner(relative: Path, root: Path) -> str | None:
+    """The other side of a twin for `relative` (from root), or None if it isn't a twin here.
+
+    Fires only when a `template/` dir exists (the dogfood repo). Editing a root twin points at
+    its `template/` source; editing under `template/` points back at the root copy.
+    """
+    if not (root / "template").is_dir():
+        return None
+    parts = relative.parts
+    if parts and parts[0] == "template":
+        # template/<...>/name.jinja → strip the leading `template/`, the `.jinja` suffix, and any
+        # `{% if ... %}segment{% endif %}` conditional-dir wrappers, giving the root twin path.
+        inner = Path(*parts[1:])
+        stem = inner.with_suffix("") if inner.suffix == ".jinja" else inner
+        root_rel = "/".join(re.sub(r"\{%.*?%\}", "", segment) or segment for segment in stem.parts)
+        return root_rel if root_rel in WATCHED and (root / root_rel).exists() else None
+    posix = relative.as_posix()
+    return f"template/{posix}(.jinja) source" if posix in WATCHED else None
+
+
+def _banned_table(content: str) -> tuple[str, str] | None:
+    """(table, home) for the first banned `[tool.<x>]` table in `content`, else None."""
+    for table, home in BANNED_PYPROJECT_TABLES.items():
+        if re.search(rf"(?m)^\[tool\.{re.escape(table)}(?:\.[^\]]+)?\]", content):
+            return table, home
+    return None
+
+
+def decide(event: dict) -> tuple[str, str]:
+    """Pure decision: (action, message) where action is allow|deny|warn_allow."""
+    path = edited_path(event)
+    if not path:
+        return "allow", ""
+    file = Path(path).resolve()
+    root = project_root(file.parent)
+    if root is None:
+        return "allow", ""
+    try:
+        relative = file.relative_to(root)
+    except ValueError:
+        return "allow", ""
+
+    # Behavior 2 (BLOCK): a banned language-agnostic table in pyproject.toml.
+    if relative.name == "pyproject.toml" and relative.parent == Path():
+        content = resulting_content(event, file)
+        if content is not None and (hit := _banned_table(content)) is not None:
+            table, home = hit
+            return "deny", (
+                f"Blocked: [tool.{table}] is language-agnostic config and must not live in "
+                f"pyproject.toml (which only exists for Python projects here). Put it in {home} "
+                f"instead, its language-neutral home."
+            )
+
+    # Behavior 1 (WARN): twin drift.
+    partner = _twin_partner(relative, root)
+    if partner is not None:
+        return "warn_allow", (
+            f"guard_config_drift: {relative} is a dogfood twin — keep its partner ({partner}) in "
+            f"sync, or run `python scripts/resync_twins.py` after this edit. (Allowing the edit.)"
+        )
+    return "allow", ""
+
+
+def main() -> None:
+    dispatch(*decide(read_event()))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/guard_managed_files.py
+++ b/.claude/hooks/guard_managed_files.py
@@ -1,0 +1,68 @@
+"""PreToolUse guard: block hand-edits to tool-owned files.
+
+`uv.lock` (uv), `CHANGELOG.md` (release-please), `.copier-answers.yml` (copier), and everything
+under `LICENSES/` (REUSE/the license tooling) are owned by a tool that regenerates them. A
+hand-edit silently drifts the file from its owner. This blocks Edit/Write to those paths.
+Matching is root-anchored on the edited file's nearest `.git` (copier-path aware, not cwd),
+case-insensitive, and only fires for the file at the PROJECT ROOT — a `docs/CHANGELOG.md` a user
+authored is not the release-please one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# _hooklib is the sibling module on sys.path (script dir when run, harness-inserted when imported).
+from _hooklib import dispatch, edited_path, project_root, read_event
+
+# Tool-owned files at the project root (compared case-insensitively).
+MANAGED_ROOT_FILES = frozenset({"uv.lock", "changelog.md", ".copier-answers.yml"})
+# Tool-owned directories at the project root (the whole subtree is owned).
+MANAGED_ROOT_DIRS = frozenset({"licenses"})
+
+_OWNER = {
+    "uv.lock": "uv (run `uv lock` / `uv sync`)",
+    "changelog.md": "release-please (it rewrites this on each release)",
+    ".copier-answers.yml": "copier (it rewrites this on `copier copy`/`update`)",
+    "licenses": "the license tooling (REUSE / your license list)",
+}
+
+
+def _managed_key(relative: Path) -> str | None:
+    """The owner key if `relative` (from the project root) is tool-owned, else None."""
+    parts = [part.lower() for part in relative.parts]
+    if len(parts) == 1 and parts[0] in MANAGED_ROOT_FILES:
+        return parts[0]
+    if parts and parts[0] in MANAGED_ROOT_DIRS:
+        return parts[0]
+    return None
+
+
+def decide(event: dict) -> tuple[str, str]:
+    """Pure decision: (action, message) where action is allow|deny."""
+    path = edited_path(event)
+    if not path:
+        return "allow", ""
+    file = Path(path).resolve()
+    root = project_root(file.parent)
+    if root is None:
+        return "allow", ""
+    try:
+        relative = file.relative_to(root)
+    except ValueError:
+        return "allow", ""
+    key = _managed_key(relative)
+    if key is None:
+        return "allow", ""
+    return "deny", (
+        f"Blocked: {relative} is owned by {_OWNER[key]}, not hand-edited. "
+        f"Change it through its tool so it doesn't drift, or delete this guard if you really must."
+    )
+
+
+def main() -> None:
+    dispatch(*decide(read_event()))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/guard_version_bumps.py
+++ b/.claude/hooks/guard_version_bumps.py
@@ -1,0 +1,158 @@
+"""PreToolUse guard: block a hand-edit that moves the release-please version off canonical.
+
+release-please owns the version bump. A stray hand-edit that changes it is only caught
+indirectly today — via a later release-please conflict. This guard blocks an Edit/Write that
+sets the version-of-record (the `.config/.release-please-manifest.json` value, or any file
+release-please mirrors it into via `extra-files`) to a value OTHER than the canonical one.
+Rewriting the identical value is allowed. If canonical can't be resolved, it fails open loudly.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+# _hooklib is the sibling module in this same dir; it resolves both when Claude Code runs this
+# as a script (the script's dir is on sys.path) and when the test harness imports it after
+# putting this dir on sys.path.
+from _hooklib import (
+    dispatch,
+    edited_path,
+    project_root,
+    read_event,
+    resulting_content,
+)
+
+MANIFEST_REL = Path(".config") / ".release-please-manifest.json"
+CONFIG_REL = Path(".config") / "release-please-config.json"
+
+
+def _manifest_version(data: dict) -> str | None:
+    """The single-package version from a release-please manifest ('.' key, or the sole entry)."""
+    if "." in data:
+        return data["."]
+    return next(iter(data.values())) if len(data) == 1 else None
+
+
+def canonical_version(root: Path) -> tuple[str | None, str | None]:
+    """(version, error): the manifest's canonical version, or (None, reason) if unresolvable."""
+    manifest = root / MANIFEST_REL
+    try:
+        data = json.loads(manifest.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"could not read {MANIFEST_REL}: {exc}"
+    version = _manifest_version(data)
+    if not version:
+        return None, f"no single-package version in {MANIFEST_REL}"
+    return version, None
+
+
+def version_carriers(root: Path) -> set[Path]:
+    """Every file that carries the version: the manifest + release-please's `extra-files`.
+
+    Derived from THIS repo's own release-please-config.json (not a hardcoded list), so it tracks
+    whatever a given project actually syncs — pyproject.toml / uv.lock for Python, galaxy.yml for
+    an Ansible collection, nothing extra for a config-only repo.
+    """
+    carriers = {(root / MANIFEST_REL).resolve()}
+    try:
+        config = json.loads((root / CONFIG_REL).read_text())
+    except (OSError, json.JSONDecodeError):
+        return carriers
+    for package in (config.get("packages") or {}).values():
+        for extra in package.get("extra-files") or []:
+            path = extra.get("path") if isinstance(extra, dict) else extra
+            if path:
+                carriers.add((root / path).resolve())
+    return carriers
+
+
+def version_in(content: str, file: Path) -> str | None:
+    """The version this file's post-edit `content` declares, by the file's own convention."""
+    name = file.name.lower()
+    if name == MANIFEST_REL.name:
+        try:
+            return _manifest_version(json.loads(content))
+        except (json.JSONDecodeError, AttributeError):
+            return None
+    if name == "pyproject.toml":
+        # `$.project.version` — the first line-anchored `version = "..."` (the [project] one;
+        # dependency pins are inline tables, never a bare top-of-line assignment).
+        match = re.search(r'(?m)^\s*version\s*=\s*["\']([^"\']+)["\']', content)
+        return match.group(1) if match else None
+    if name == "galaxy.yml":
+        match = re.search(r'(?m)^version:\s*["\']?([^"\'\s]+)', content)
+        return match.group(1) if match else None
+    return None
+
+
+def _decide_manifest_edit(root: Path, content: str) -> tuple[str, str]:
+    """Guard an edit to the manifest by comparing the WHOLE dict — single AND multi-package.
+
+    The manifest is the version-of-record; a per-package canonical can't be expressed as one
+    value, so compare every package's version rather than a single one. Deny when any managed
+    version changes (a hand bump); allow an identical rewrite.
+    """
+    try:
+        current = json.loads((root / MANIFEST_REL).read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        return (
+            "warn_allow",
+            f"guard_version_bumps: can't read the current manifest ({exc}); allowing the edit (fail-open).",
+        )
+    try:
+        new = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        return "allow", ""  # the edit doesn't leave valid JSON — not a version change to adjudicate
+    if not isinstance(new, dict):
+        return "allow", ""
+    changed = sorted(pkg for pkg in set(current) | set(new) if current.get(pkg) != new.get(pkg))
+    if not changed:
+        return "allow", ""
+    return "deny", (
+        f"Blocked: this edit changes the release-please-managed version of {', '.join(changed)} "
+        f"in {MANIFEST_REL.name}. release-please owns version bumps — don't hand-edit the manifest "
+        f"(rewriting the same values is fine). To release, let release-please's Release PR bump it."
+    )
+
+
+def decide(event: dict) -> tuple[str, str]:
+    """Pure decision: returns (action, message) where action is allow|deny|warn_allow."""
+    path = edited_path(event)
+    if not path:
+        return "allow", ""
+    file = Path(path).resolve()
+    root = project_root(file.parent)
+    if root is None or file not in version_carriers(root):
+        return "allow", ""
+    content = resulting_content(event, file)
+    if content is None:
+        return "allow", ""
+    # The manifest carries every package's version-of-record, so compare it whole — this is what
+    # makes the guard cover a multi-package (monorepo) manifest, not just a single `.` package.
+    if file == (root / MANIFEST_REL).resolve():
+        return _decide_manifest_edit(root, content)
+    # A non-manifest carrier (pyproject/galaxy) mirrors the single-package canonical version.
+    canonical, error = canonical_version(root)
+    if canonical is None:
+        return (
+            "warn_allow",
+            f"guard_version_bumps: can't resolve the canonical version ({error}); allowing the edit (fail-open).",
+        )
+    new_version = version_in(content, file)
+    if new_version is None or new_version == canonical:
+        return "allow", ""
+    return "deny", (
+        f"Blocked: this edit sets the version in {file.name} to {new_version}, but release-please's "
+        f"canonical version is {canonical}. release-please owns version bumps — don't hand-edit "
+        f"the version (rewriting the same value is fine). To release, let release-please's PR bump it."
+    )
+
+
+def main() -> None:
+    dispatch(*decide(read_event()))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard_version_bumps.py\""
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard_managed_files.py\""
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard_config_drift.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.config/licenserc.toml
+++ b/.config/licenserc.toml
@@ -26,6 +26,13 @@ excludes = [
   "**/.vscode/*",
   # CODEOWNERS has no extension hawkeye maps; it carries its own `#` header (reuse-verified).
   "**/CODEOWNERS",
+  # GitHub's issue-form parser silently rejects a form whose YAML begins with a comment (it
+  # falls back to a blank issue), so ISSUE_TEMPLATE/*.yml must start with the form keys and
+  # can't carry an inline SPDX header — excluded here and licensed via REUSE.toml instead.
+  ".github/ISSUE_TEMPLATE/**",
+  # The Claude Code guard hooks ship verbatim from the template (no per-file templating), so
+  # they carry no inline header — excluded here and licensed via REUSE.toml instead.
+  ".claude/hooks/**",
 ]
 
 additionalHeaders = ["markdown-header.toml"]

--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -13,4 +13,13 @@ exclude = [
   # The REUSE badge's /info/ endpoint 404s until this repo is registered/crawled by
   # reuse.software (the /badge/ SVG still renders); self-heals once registered.
   "api\\.reuse\\.software/info/",
+  # Documentation universals — safe to exclude in any project's docs.
+  # Loopback / local-dev hosts that never resolve in CI.
+  "^https?://(localhost|127\\.0\\.0\\.1)([:/]|$)",
+  # RFC 2606 reserved example domains — placeholders, never real links.
+  "^https?://([^/@]+\\.)?example\\.(com|org|net)([:/]|$)",
+  # A not-yet-published private GitHub Pages site — REQUIRES a subdomain label (`x.pages.github.io`),
+  # so the bare `pages.github.io` (GitHub's Pages home/docs) still gets link-checked. The `([:/]|$)`
+  # boundary after `pages.github.io` keeps a spoof host like `evil-pages.github.io.attacker.com` out.
+  "^https?://[^/@]+\\.pages\\.github\\.io([:/]|$)",
 ]

--- a/.config/release-please-config.json
+++ b/.config/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "separate-pull-requests": true,
   "packages": {
     ".": {
       "extra-files": [

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY.
-_commit: v1.11.1
+_commit: v1.12.0
 _src_path: gh:nivintw/copier-everything
 author_email: tyler@nivin.tech
 author_name: Tyler Nivin
@@ -25,6 +25,7 @@ publish_to_pypi: true
 python_package: digital_ocean_dynamic_dns
 python_source: true
 python_version: '3.12'
+release_model: single
 repo_name: ddns
 repo_owner: nivintw
 test_frameworks:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: © 2023 Tyler Nivin
-# SPDX-License-Identifier: MIT
-
 name: 🐛 Bug report
 description: Report a problem with Digital Ocean Dynamic DNS
 labels: [bug]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
-# SPDX-FileCopyrightText: © 2023 Tyler Nivin
-# SPDX-License-Identifier: MIT
-
-# Force issues through the structured forms above (no blank issues).
-blank_issues_enabled: false
+blank_issues_enabled: false # force issues through the structured forms (no blank issues)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: © 2023 Tyler Nivin
-# SPDX-License-Identifier: MIT
-
 name: ✨ Feature request
 description: Suggest an idea for Digital Ocean Dynamic DNS
 labels: [enhancement]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,8 +17,8 @@
       "groupName": "ruff"
     },
     {
-      "description": "Only re-run the checksum refresh when one of the 5 tools the customManager below discovers via its # renovate: annotations actually changed — so an unrelated update (a ruff-pre-commit bump, an actions/checkout digest bump, etc.) doesn't also shell out to 5 external release hosts. BASE_REF is computed inline (merge-base against the default branch) rather than relying on the runner to export it, so the script's supply-chain tamper gate (refuse a same-version/different-hash re-pin) is always active on this automated path — and the command fails loudly if that computation itself fails, rather than letting a silently-empty BASE_REF degrade back to the gate being off.",
-      "matchPackageNames": ["aquasecurity/trivy", "google/osv-scanner", "korandoru/hawkeye", "tamasfe/taplo", "yannh/kubeconform"],
+      "description": "Only re-run the checksum refresh when one of the tools the customManager below discovers via its # renovate: annotations actually changed — so an unrelated update (a ruff-pre-commit bump, an actions/checkout digest bump, etc.) doesn't also shell out to the external release hosts. Covers both pin classes the script refreshes: the *_SHA256 asset-bearing tools (trivy/osv/hawkeye/taplo/kubeconform) and the *_COMMIT asset-less tools (bats, pinned by the commit its tag points at). BASE_REF is computed inline (merge-base against the default branch) rather than relying on the runner to export it, so the script's supply-chain tamper gate (refuse a same-version/different-pin re-pin) is always active on this automated path — and the command fails loudly if that computation itself fails, rather than letting a silently-empty BASE_REF degrade back to the gate being off.",
+      "matchPackageNames": ["aquasecurity/trivy", "google/osv-scanner", "korandoru/hawkeye", "tamasfe/taplo", "yannh/kubeconform", "bats-core/bats-core", "gitleaks/gitleaks"],
       "postUpgradeTasks": {
         "commands": ["BASE_REF=\"$(git merge-base HEAD origin/HEAD)\" || { echo 'ERROR: could not compute BASE_REF via git merge-base — refusing to run with the tamper gate silently disabled' >&2; exit 1; }; export BASE_REF; scripts/refresh-binary-checksums.sh"],
         "fileFilters": [".github/workflows/**"],
@@ -29,7 +29,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Pinned release binaries by a `# renovate:`-annotated *_VERSION env var (trivy, osv-scanner, hawkeye, taplo, kubeconform). Renovate bumps the version; the adjacent *_SHA256 is refreshed by scripts/refresh-binary-checksums.sh, run as a postUpgradeTask (in packageRules above, scoped to these 5 tools) so the fix lands in Renovate's own commit, since github-releases exposes no asset-digest datasource.",
+      "description": "Pinned release binaries by a `# renovate:`-annotated *_VERSION env var (trivy, osv-scanner, hawkeye, taplo, kubeconform, and bats). Renovate bumps the version; the adjacent pin (*_SHA256 for asset-bearing tools, *_COMMIT for asset-less bats) is refreshed by scripts/refresh-binary-checksums.sh, run as a postUpgradeTask (in packageRules above, scoped to these tools) so the fix lands in Renovate's own commit, since github-releases exposes no asset-digest datasource.",
       "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+\\w+: \"(?<currentValue>[^\"]+)\""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # fetch-depth: 0 so gitleaks scans the WHOLE history, not just the tip. The pre-commit
+          # `gitleaks --staged` hook is a no-op in CI's clean checkout (nothing is staged), so
+          # without this job a generated project ships effectively zero CI secret scanning — and
+          # a secret committed then removed in a later commit is invisible to a tip-only scan.
+          fetch-depth: 0
+          # Read-only gate — don't leave the checkout token in .git/config (zizmor artipacked).
+          persist-credentials: false
+      - name: Scan full git history for secrets (gitleaks)
+        if: inputs.skip-quality-gate != true
+        env:
+          # renovate: datasource=github-releases depName=gitleaks/gitleaks
+          GITLEAKS_VERSION: "8.30.1"
+          # SHA256 of gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz — refreshed with the version
+          # by scripts/refresh-binary-checksums.sh.
+          GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"  # gitleaks:allow
+        run: |
+          set -euo pipefail
+          # Fail loudly on a shallow checkout rather than silently scanning a partial history —
+          # a shallow clone would turn this full-history scan into a false all-clear.
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            echo "::error::Checkout is shallow — gitleaks would scan only partial history. Ensure fetch-depth: 0."
+            exit 1
+          fi
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            -o "$RUNNER_TEMP/gitleaks.tar.gz"
+          echo "${GITLEAKS_SHA256}  $RUNNER_TEMP/gitleaks.tar.gz" | sha256sum -c -
+          tar -xz -C "$RUNNER_TEMP" -f "$RUNNER_TEMP/gitleaks.tar.gz" gitleaks
+          "$RUNNER_TEMP/gitleaks" git --redact --verbose .
+
   lint-and-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,13 +4,16 @@
 # Main pipeline: on every push to main, run the SAME quality gate as PRs, then — only
 # here — release-please (gated by `needs: ci`).
 #
-# RELEASE FLOW (release-please, manifest mode — single package):
+# RELEASE FLOW (release-please, manifest mode, separate-pull-requests: true — N-package
+# generic; this template scaffolds a single package "." by default, the N=1 case of the
+# same mechanism):
 #   1. On push to main, release-please scans Conventional Commits since the last release
-#      and maintains a "Release PR" that bumps the version (.config/.release-please-manifest.json,
-#      mirrored into the version-of-record via .config/release-please-config.json's extra-files)
-#      + CHANGELOG.md.
-#   2. That Release PR is auto-merged (`--auto --rebase`) once its required checks pass, so
-#      releases are continuous; release-please then cuts the `vX.Y.Z` tag + GitHub Release.
+#      and maintains one Release PR per package that bumps that package's version
+#      (.config/.release-please-manifest.json, mirrored into the version-of-record via
+#      .config/release-please-config.json's extra-files) + CHANGELOG.md.
+#   2. Every open Release PR is auto-merged (`--auto --rebase`) once its required checks
+#      pass, so releases are continuous; release-please then cuts each package's `vX.Y.Z`
+#      tag + GitHub Release.
 #   3. The action authenticates as the release GitHub App (see below). An App token is a
 #      distinct actor, so — unlike the default GITHUB_TOKEN — the Release PR runs CI and
 #      merging it triggers downstream workflows.
@@ -96,7 +99,7 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - name: Run release-please (Release PR, tag, release)
+      - name: Run release-please (Release PRs, tags, releases)
         id: release
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
@@ -104,40 +107,60 @@ jobs:
           config-file: .config/release-please-config.json
           manifest-file: .config/.release-please-manifest.json
 
-      # Continuous release: enable auto-merge on the Release PR so it lands (rebase) once
-      # required checks pass. On the next run (release cut, no PR) `pr` is empty and this
-      # skips. PR JSON travels via env, never inline `${{ }}`, to dodge script injection.
-      # GH_REPO tells gh which repo to act on: this job has no checkout, so without it
-      # `gh pr merge` probes the working dir for a git remote and dies ("not a git
-      # repository"). gh reads GH_REPO natively, so no `actions/checkout` is needed.
+      # Continuous release: enable auto-merge on EVERY open Release PR, so each lands
+      # (rebase) once required checks pass. Because separate-pull-requests is on,
+      # release-please emits `prs` (a JSON array of every Release PR touched this run) —
+      # iterating it is what makes this generic across however many packages the config
+      # declares, from this template's default of one up to however many a consumer adds
+      # by hand. On the next run (a release was cut, no PR) `prs` is unset and this skips.
+      # PR JSON travels via env, never inline `${{ }}`, to dodge script injection. GH_REPO
+      # tells gh which repo to act on: this job has no checkout, so without it `gh pr merge`
+      # probes the working dir for a git remote and dies ("not a git repository"). gh reads
+      # GH_REPO natively, so no `actions/checkout` is needed.
       # Tolerate ONLY the documented setup gap — a repo that hasn't turned on "Allow
       # auto-merge" — by detecting it up front (the repo's allow_auto_merge flag) and warning
       # cleanly. Every OTHER failure (gh API 5xx, auth, a missing required check on main)
       # then reddens the job under `set -euo pipefail`, so a stalled release is loud instead
       # of hiding as a ::warning:: on an otherwise-green run.
-      - name: Auto-merge the Release PR
-        if: ${{ steps.release.outputs.pr }}
+      # `!= '[]'` is defensive belt-and-suspenders, not load-bearing today: verified against
+      # release-please-action v4.4.1's source that `prs` is only ever set (never to `"[]"`)
+      # when at least one PR exists — but the action isn't pinned by version, just by commit
+      # SHA that Renovate bumps, so this guards against a future release changing that.
+      - name: Auto-merge the Release PRs
+        if: ${{ steps.release.outputs.prs && steps.release.outputs.prs != '[]' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
-          RELEASE_PR: ${{ steps.release.outputs.pr }}
+          RELEASE_PRS: ${{ steps.release.outputs.prs }}
         run: |
           set -euo pipefail
-          num="$(printf '%s' "$RELEASE_PR" | jq -r '.number')"
+          # Capture jq's output first (not `jq | while`): under `set -e` a jq failure (null /
+          # non-array `prs`) aborts the step loudly instead of being swallowed by the pipe and
+          # silently enabling auto-merge on nothing. Computed before the auto_merge_allowed
+          # check too, so a disabled-auto-merge warning can name the exact PR(s) to merge
+          # manually instead of pointing at a discovery step.
+          numbers="$(printf '%s' "$RELEASE_PRS" | jq -r '.[].number')"
           # Read the setting in its own statement so a gh API failure here (5xx/auth) trips
           # set -e and reddens the job, rather than the empty result masquerading as "off".
           auto_merge_allowed="$(gh api "repos/${GH_REPO}" --jq '.allow_auto_merge')"
           if [ "$auto_merge_allowed" != "true" ]; then
-            echo "::warning::Auto-merge is off for ${GH_REPO}, so Release PR #${num} was left open. Enable 'Allow auto-merge' + 'Allow rebase merging' and require a status check on main, then merge it (manually for now)."
+            # `paste -d` treats a multi-char delimiter as a cycling set of characters, not a
+            # literal string, so it'd alternate ',' and ' ' across 3+ items — join on a single
+            # char first, then widen it to ", ".
+            pr_list="$(echo "$numbers" | sed 's/^/#/' | paste -sd, - | sed 's/,/, /g')"
+            echo "::warning::Auto-merge is off for ${GH_REPO}, so Release PR(s) ${pr_list} were left open (merge manually once ready). Enable 'Allow auto-merge' + 'Allow rebase merging' and require a status check on main to automate this."
             exit 0
           fi
-          gh pr merge "$num" --auto --rebase
+          for num in $numbers; do
+            gh pr merge "$num" --auto --rebase
+          done
 
       # This template's own release-please-config.json.jinja always scaffolds a single
-      # package, so this never fires against a freshly-generated repo as-is — it guards the
-      # moment a consumer extends that config to 2+ packages by hand (release-please
-      # supports it; the config is a plain file a consumer can and does edit), which is
-      # exactly the real-world incident that motivated this fix. Once that happens: each
+      # package by default, so this never fires against a freshly-generated repo as-is —
+      # it guards the moment a consumer extends that config to 2+ packages by hand
+      # (release-please supports it, separate-pull-requests is already on above, and the
+      # config is a plain file a consumer can and does edit), which is exactly the
+      # real-world incident that motivated this fix. Once that happens: each
       # package's Release PR bumps its own line in the SHARED manifest, so the first to
       # auto-merge above changes main and every other Release PR's branch now textually
       # conflicts with main on that shared file (mergeStateStatus DIRTY) and can never
@@ -164,57 +187,65 @@ jobs:
           CI_APP_SLUG: ${{ vars.CI_APP_SLUG }}
         run: |
           set -euo pipefail
-          # `gh pr list --jq` only accepts a single filter expression (no `--arg` passthrough,
-          # unlike standalone jq) — piping through jq directly instead. Assigning the listing
-          # to a variable (rather than `mapfile < <(...)`, which runs the producer in a process
-          # substitution whose exit status `set -e` can't see) makes a `gh pr list` failure
-          # (auth, API 5xx) abort the step loudly instead of silently reading as "none found".
-          # --limit raised well past gh's 30-item default so a busier repo's stranded PR can't
-          # fall off the first page.
-          #
-          # `commits` is deliberately NOT requested here: GitHub's GraphQL backend charges a
-          # node budget for every nested connection a query traverses (PR -> commits ->
-          # authors), and at --limit 100 that blows straight through the 500,000-node ceiling
-          # ("By the time this query traverses to the authors connection, it is requesting up
-          # to 1,000,000 possible nodes") — reproduced live against this exact repo/query, not
-          # a theoretical concern. Fetching commits per stranded candidate below instead costs
-          # at most a handful of extra API calls, since a repo normally has 0-1 stranded
-          # Release PRs open at any time.
+          # Two-phase on purpose. Phase 1 lists open PRs on CHEAP fields only and must NOT
+          # request `commits`: `gh pr list --json ...,commits` makes GitHub's GraphQL cost
+          # estimator score the nested commits→authors connection across the whole requested
+          # page (roughly limit × 100 commits × authors) and REJECT the query before it runs
+          # once the page size passes ~50 ("requesting up to N possible nodes ... exceeds the
+          # maximum limit of 500,000"). It fails on the query SHAPE, independent of how many PRs
+          # or commits actually exist — so requesting commits here reddened this step on
+          # essentially every run once CI_APP_SLUG was set. `commits` is fetched per stranded
+          # candidate in phase 2 instead (a repo normally has 0-1 stranded Release PRs open at
+          # once, so that's a couple of extra calls, not one per open PR).
+          # Plain assignment (not `mapfile < <(...)`, a process substitution whose exit status
+          # `set -e` can't see) so a `gh pr list` failure (auth, API 5xx) aborts the step loudly
+          # instead of silently reading as "none found". --limit raised well past gh's 30-item
+          # default so a busier repo's stranded PR can't fall off the first page.
           prs_json="$(gh pr list --state open --limit 100 \
             --json number,author,labels,mergeStateStatus)"
-          # Same reasoning as above: a plain assignment (not `mapfile < <(...)`) so a jq
-          # failure trips `set -e` too, instead of silently reading as "none found". An empty
-          # filter result is a legitimate zero-matches outcome, not a failure — `mapfile` from
-          # an empty string yields a one-element array holding "", so that case is normalized
-          # back to a true zero-length array below.
-          stranded_str="$(printf '%s' "$prs_json" | jq -r --arg app "${CI_APP_SLUG}[bot]" \
+          # Narrow to the stranded candidates on those cheap fields: authored by the release
+          # bot, labeled `autorelease: pending`, and DIRTY. Literal equality against DIRTY (not
+          # "!= CLEAN"): mergeStateStatus is transiently UNKNOWN right after a push, so a
+          # just-orphaned PR simply isn't caught this run and converges on a later one rather
+          # than being misclassified. Plain assignment again so a jq failure trips `set -e`.
+          candidates="$(printf '%s' "$prs_json" | jq -r --arg app "${CI_APP_SLUG}[bot]" \
             '.[] | select(.author.login == $app and (.labels[]?.name == "autorelease: pending") and .mergeStateStatus == "DIRTY") | .number')"
-          stranded=()
-          if [ -n "$stranded_str" ]; then
-            mapfile -t stranded <<<"$stranded_str"
-          fi
-          if [ "${#stranded[@]}" -eq 0 ]; then
+          if [ -z "$candidates" ]; then
             echo "No stranded Release PRs found."
             exit 0
           fi
-          for num in "${stranded[@]}"; do
-            # Never auto-close a stranded PR carrying a human's manual commit: the PR's
-            # author field is immutable (release-please's bot login), so a maintainer's
-            # fixup pushed directly onto the bot's branch still matches the filter above —
-            # closing it under the "release-please will regenerate this PR" message would
-            # silently discard those commits, not just an auto-generated bump. Checked here
-            # from the branch's actual commits (a persistent record, unlike the mutable
-            # `author` field) rather than trusting the PR-level author.
-            #
-            # A commit author with no linked GitHub account (an unlinked git email) comes
-            # back with a null OR empty-string `.login`/`.email` — falling straight through
-            # `//` would silently collapse a real human commit to an empty string (jq's `//`
-            # treats "" as truthy, so a bare `.login // .email // .name` wouldn't fall through
-            # for either field), defeating this whole check. Explicitly treat both null and ""
-            # as "absent" at every step of the fallback chain, not just the first one.
-            non_bot_logins="$(gh pr view "$num" --json commits | jq -r --arg app "${CI_APP_SLUG}[bot]" \
-              '[.commits[].authors[]? | select(.login != $app) | ((.login | select(. != null and . != "")) // (.email | select(. != null and . != "")) // .name // "unknown-author")] | unique | join(", ")')"
+          mapfile -t nums <<<"$candidates"
+          for num in "${nums[@]}"; do
+            [ -n "$num" ] || continue
+            # Phase 2: fetch THIS candidate's commits (the split's cost, bought back cheaply).
+            # Its own statement so a `gh pr view` failure trips `set -e` instead of reading as
+            # "no commits".
+            commits_json="$(gh pr view "$num" --json commits)"
+            # Never auto-close a stranded PR carrying a human's manual commit: closing it under
+            # the "release-please will regenerate this PR" message would silently discard those
+            # commits, not just an auto-generated bump. Checked from the branch's actual commits
+            # (which can gain new commits over time) rather than trusting the PR-level `author`
+            # field (fixed once the PR opens, so it can't reflect who pushed a later fixup
+            # commit — it stays the release bot's login either way).
+            # Fail SAFE (leave open) on any degraded shape this check can't verify, resolving it
+            # to a non-empty "unknown-authors" marker rather than an empty string:
+            #   - a null/absent `.commits` (whole response degraded), and
+            #   - a commit whose `.authors` is empty/null/absent (per-commit degraded) — without
+            #     this, that commit's authors iterate to nothing, the list collapses to "", and
+            #     the [ -n ] check below reads "" as "verified bot-only" and auto-closes the PR,
+            #     discarding a human's commit (the opposite of this guard's fail-safe direction).
+            # A naive `.commits[]?`/`.authors[]?` would silently swallow both into "verified
+            # bot-only" instead. A commit author with no linked GitHub account comes back with a
+            # null OR empty-string `.login` AND/OR `.email`; jq's `//` treats "" as truthy, so
+            # guard both null and "" on EACH field before falling through, or a `login: null,
+            # email: ""` human commit would collapse to "" and be misread as bot-only.
+            non_bot_logins="$(printf '%s' "$commits_json" | jq -r --arg app "${CI_APP_SLUG}[bot]" \
+              'if .commits == null then "unknown-authors (commits field missing from API response)" elif any(.commits[]; (.authors // []) | length == 0) then "unknown-authors (a commit is missing author data)" else ([.commits[].authors[]? | select(.login != $app) | ((.login | select(. != null and . != "")) // (.email | select(. != null and . != "")) // .name // "unknown-author")] | unique | join(", ")) end')"
             if [ -n "$non_bot_logins" ]; then
+              # Strip CR/LF from the (attacker-influenceable) author string before echoing it
+              # into a ::warning:: — a forged commit author name containing a newline could
+              # otherwise inject spurious GitHub Actions workflow-command annotations (log spoof).
+              non_bot_logins="${non_bot_logins//[$'\r\n']/ }"
               echo "::warning::Release PR #${num} is DIRTY but carries a commit from ${non_bot_logins} (not just ${CI_APP_SLUG}[bot]) — leaving it open rather than auto-closing, since that would discard those commits. Resolve the conflict manually."
               continue
             fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -187,8 +187,16 @@ jobs:
               if ep.dist and ep.dist.name == "digital-ocean-dynamic-dns"
           ]
           if entry_points:
-              subprocess.run([entry_points[0].name, "--help"], check=True)
+              entry_point = entry_points[0]
+              print(f"::notice::Exercising console script '{entry_point.name}'")
+              subprocess.run([entry_point.name, "--help"], check=True)
           else:
+              # A package with no console script is legitimate, so this stays a pass — but a
+              # package that's SUPPOSED to ship one and doesn't (a mistyped/deleted
+              # [project.scripts] entry, a build-backend regression that drops
+              # entry_points.txt) would otherwise pass the smoke test silently. The warning
+              # makes that visible in the job log without changing pass/fail semantics.
+              print("::warning::No console_scripts entry point found; smoke-testing via import only")
               import digital_ocean_dynamic_dns
           PY
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -224,6 +224,13 @@ repos:
         entry: prek validate-config
         language: system
         files: '^\.pre-commit-config\.yaml$'
+      - id: check-copier-src-path
+        name: "🔧 copier · Require a remote _src_path (not a local path)"
+        # A local _src_path silently breaks `copier update` for every other clone and in CI.
+        entry: python3 scripts/check_copier_src_path.py
+        language: system
+        files: '^\.copier-answers\.yml$'
+        pass_filenames: true
 
       - id: ty
         name: "🐍 python · Type-check with ty"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -18,6 +18,23 @@ SPDX-FileCopyrightText = "© 2023 Tyler Nivin"
 SPDX-License-Identifier = "MIT"
 
 
+# The issue-form templates: GitHub's issue-form parser silently rejects a form whose YAML
+# begins with a comment (falling back to a blank issue), so these must start with the form
+# keys and can't carry an inline SPDX header — hawkeye is told to skip them (see
+# .config/licenserc.toml) and they're licensed here instead.
+[[annotations]]
+path = ".github/ISSUE_TEMPLATE/**"
+SPDX-FileCopyrightText = "© 2023 Tyler Nivin"
+SPDX-License-Identifier = "MIT"
+
+# The Claude Code guard hooks ship verbatim from the template (no per-file templating), so they
+# carry no inline SPDX header and are excluded from hawkeye (see .config/licenserc.toml) —
+# licensed here instead.
+[[annotations]]
+path = ".claude/hooks/**"
+SPDX-FileCopyrightText = "© 2023 Tyler Nivin"
+SPDX-License-Identifier = "MIT"
+
 # Files that can't carry an SPDX header (no comment syntax / generated). Everything
 # else gets a real header from hawkeye (see .config/licenserc.toml).
 [[annotations]]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,16 +69,16 @@ theme:
 # Overrides Material's default `code { word-break: break-word }`, which otherwise breaks
 # long identifiers (e.g. `project_name`) mid-word inside narrow table columns — see
 # stylesheets/extra.css (scaffolded alongside this file) for the fix itself.
+#
+# The asciinema-player assets are deliberately NOT wired here. extra_css/extra_javascript load
+# site-wide on EVERY page, and no template task vendors docs/assets/asciinema-player.{css,min.js},
+# so wiring them unconditionally 404s both requests on every page of any docs site that hasn't
+# embedded a cast yet (nivintw/copier-everything#172). Embedding a cast is an opt-in step that
+# adds the two vendored asset files AND their extra_css/extra_javascript lines together (see
+# castify's embedding.md reference doc) — never one without the other. tests/test_docs_site.py
+# guards against a #196-style "restore the missing wiring" change reintroducing the 404.
 extra_css:
   - stylesheets/extra.css
-
-# The asciinema-player extra_css/extra_javascript wiring the template unconditionally
-# re-added in v1.11.1 (restoring nivintw/copier-everything#196) is left out here: ddns has
-# no embedded `.cast` recordings, and those tags 404 on every page load until a repo
-# vendors docs/assets/asciinema-player.{css,min.js} — the exact regression of
-# nivintw/copier-everything#172 (already fixed once, filed again as #206). Per
-# generate-docs's SKILL.md convention, add both lines back only when this repo embeds its
-# first cast.
 
 # Adding this key at all switches MkDocs off its implicit default plugin set (just
 # `search`), so `search` is listed explicitly below or built-in search silently

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,10 @@ branch = true
 [tool.ruff]
 target-version = "py312"
 line-length = 100
+# The Claude Code guard hooks ship from the template as-is, so they aren't this project's own
+# code to lint (a future ruff rule shouldn't redden your CI over them). The `**/.claude/hooks`
+# glob matches them at any depth.
+extend-exclude = ["**/.claude/hooks"]
 
 [tool.ruff.format]
 docstring-code-format = true
@@ -84,6 +88,8 @@ ignore = ["D203", "D212", "D401", "COM812", "ISC001"]
 convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
+# CLI scripts print to the user (T201) and aren't an importable package (INP001).
+"scripts/**" = ["T201", "INP001"]
 # Tests are held to the same bar as src, with one exception: pytest *is* the `assert`
 # statement (it rewrites them), so S101 can't apply. Everything else — annotations,
 # docstrings, naming, unused args — is fixed in the tests, not ignored.

--- a/scripts/check_copier_src_path.py
+++ b/scripts/check_copier_src_path.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: © 2023 Tyler Nivin
+# SPDX-License-Identifier: MIT
+
+
+"""Assert that .copier-answers.yml records a REMOTE `_src_path`, not a local path.
+
+Copier writes the template location it was run from into `_src_path`. If a project is
+scaffolded (or updated) from a LOCAL filesystem checkout of the template, that local path
+gets recorded — and then `copier update` silently breaks for every OTHER clone and in CI,
+because the path doesn't exist there. This gate fails the commit when `_src_path` is a
+local path so the mistake is caught at the source instead of surfacing as a broken update
+somewhere else.
+
+Stdlib only, on purpose: a generated project's pre-commit hook env is not guaranteed to
+have PyYAML, so we don't import it. We only need a single scalar line, which we pull out
+with a regex — this is NOT a general YAML parser.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# `_src_path:` at the start of a line, capturing the rest of the line (trailing space trimmed).
+_SRC_PATH_RE = re.compile(r"^_src_path:\s*(.*?)\s*$", re.MULTILINE)
+
+# Remote forms that `copier update` can reach from any clone / from CI:
+#   scheme URLs .......... ssh:// https:// http:// git://
+#   copier shorthand ..... gh:owner/repo, gl:owner/repo
+#   scp-like git URL ..... git@host:owner/repo
+_REMOTE_SCHEME_RE = re.compile(r"^(?:ssh|https?|git)://", re.IGNORECASE)
+_SHORTHAND_RE = re.compile(r"^(?:gh|gl):.+", re.IGNORECASE)
+_SCP_RE = re.compile(r"^[A-Za-z0-9_.+-]+@[A-Za-z0-9._-]+:.+")
+
+_DEFAULT_ANSWERS = ".copier-answers.yml"
+_REMEDY = (
+    "Set `_src_path` to the remote template URL (e.g. gh:nivintw/copier-everything) "
+    "and re-run `copier update`."
+)
+
+
+def _strip_quotes(value: str) -> str:
+    """Drop a single matching pair of surrounding single/double quotes, if present."""
+    value = value.strip()
+    # `value != value[:1]` means "at least two chars" without a magic length literal — so a lone
+    # quote isn't mistaken for an empty quoted string.
+    if value[:1] in ("'", '"') and value[-1:] == value[:1] and value != value[:1]:
+        return value[1:-1]
+    return value
+
+
+def is_remote(value: str) -> bool:
+    """True when `value` is a remote template location `copier update` can resolve anywhere."""
+    return bool(
+        _REMOTE_SCHEME_RE.match(value) or _SHORTHAND_RE.match(value) or _SCP_RE.match(value)
+    )
+
+
+def check_file(path: str) -> bool:
+    """True if `path`'s `_src_path` is remote; else print the reason and return False."""
+    file = Path(path)
+    if not file.exists():
+        print(
+            f"ERROR: {path}: file not found. A generated project must have a "
+            f"{_DEFAULT_ANSWERS} recording its template source.",
+            file=sys.stderr,
+        )
+        return False
+
+    text = file.read_text(encoding="utf-8")
+    if not text.strip():
+        print(
+            f"ERROR: {path}: file is empty. Expected a Copier answers file with `_src_path`.",
+            file=sys.stderr,
+        )
+        return False
+
+    match = _SRC_PATH_RE.search(text)
+    if match is None:
+        print(
+            f"ERROR: {path}: no `_src_path:` key found. Every Copier-generated project "
+            f"records `_src_path`; this file looks wrong.",
+            file=sys.stderr,
+        )
+        return False
+
+    value = _strip_quotes(match.group(1))
+    if not value:
+        print(
+            f"ERROR: {path}: `_src_path:` is empty. {_REMEDY}",
+            file=sys.stderr,
+        )
+        return False
+
+    if is_remote(value):
+        return True
+
+    print(
+        f"ERROR: {path}: `_src_path` is a LOCAL path: {value!r}\n"
+        f"  A local `_src_path` silently breaks `copier update` for every other clone and in CI\n"
+        f"  (the path does not exist there). {_REMEDY}",
+        file=sys.stderr,
+    )
+    return False
+
+
+def main(argv: list[str]) -> int:
+    """Check each path given (pre-commit passes them), or the default answers file."""
+    paths = argv[1:] or [_DEFAULT_ANSWERS]
+    # A list (not a generator) so every path is checked and its error printed — no short-circuit.
+    results = [check_file(path) for path in paths]
+    return 0 if all(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/refresh-binary-checksums.sh
+++ b/scripts/refresh-binary-checksums.sh
@@ -2,31 +2,47 @@
 # SPDX-FileCopyrightText: © 2023 Tyler Nivin
 # SPDX-License-Identifier: MIT
 
-# Refresh the pinned SHA256 of each CI-installed release binary to match its current
-# *_VERSION. Renovate bumps the version env vars (see .github/renovate.json), but the
-# github-releases datasource has no asset-digest concept, so the adjacent *_SHA256 must be
-# recomputed from the published asset. Renovate runs this as a postUpgradeTask on its bump
-# PRs (so the refreshed hash lands in Renovate's own commit); run it by hand after a manual
-# version bump.
+# Refresh the pinned supply-chain value of each CI-installed release binary to match its
+# current *_VERSION. Renovate bumps the version env vars (see .github/renovate.json), but the
+# github-releases datasource has no asset-digest concept, so the adjacent pin must be
+# recomputed. Renovate runs this as a postUpgradeTask on its bump PRs (so the refreshed value
+# lands in Renovate's own commit); run it by hand after a manual version bump.
+#
+# Two pin classes, one refresh model:
+#   *_SHA256 — asset-bearing tools (trivy/osv/hawkeye/taplo/kubeconform). Pins the SHA256 of
+#     the published release asset (most publish a checksum file we read; taplo ships none, so
+#     we download the asset and hash it).
+#   *_COMMIT — asset-less tools (bats), installed from a git tag with NO downloadable release
+#     asset to hash. There's nothing to SHA256, so we pin the git commit id that v${VERSION}'s
+#     tag points at instead (resolved with `git ls-remote`, no clone). The BASE_REF tamper gate
+#     covers it identically: a *_COMMIT that changes while *_VERSION is unchanged is a tampered
+#     tag (a moved/re-pointed tag), same supply-chain signal as a swapped asset.
 #
 # Usage: scripts/refresh-binary-checksums.sh [file ...]
 #   With no args it updates every .github/workflows/*.yml and .github/workflows/*.yaml that
 #   carry these pins.
 #
 # Tamper gate (automation): the caller sets BASE_REF=<git ref> to enforce supply-chain
-# safety. A SHA is then only re-pinned when the *_VERSION actually changed vs BASE_REF; a SHA
+# safety. A pin is then only re-written when the *_VERSION actually changed vs BASE_REF; a pin
 # that differs from upstream while the version is UNCHANGED is treated as a tampered/swapped
-# release asset and fails the run — never silently re-pinned. The postUpgradeTask command
-# computes BASE_REF inline via `git merge-base` against the default branch (and fails loudly
-# if that computation itself fails), so the gate is always active on the automated path.
-# Without BASE_REF (a human running it locally after a deliberate bump) it just recomputes
-# every pin.
+# release (asset or tag) and fails the run — never silently re-pinned. The continuity check is
+# keyed on TOOL IDENTITY, not file path: the tool's *_VERSION is looked up across every
+# workflow file at BASE_REF, so a pin that legitimately MOVED between files (a workflow
+# restructuring, or a `copier update` renaming a generated workflow) is still recognized as the
+# same continuous pin and its gate still fires — closing the bypass where a pure file rename
+# made a same-version/changed-hash swap look like a brand-new pin. The postUpgradeTask command
+# computes BASE_REF inline via `git merge-base` against the default branch (and fails loudly if
+# that computation itself fails), so the gate is always active on the automated path. Without
+# BASE_REF (a human running it locally after a deliberate bump) it just recomputes every pin.
 #
-# Requirements: bash 4.4+, curl, sha256sum (or shasum), sed, grep, awk, mktemp, head; git when BASE_REF set.
+# Requirements: bash 3.2+ (stays parseable/runnable on macOS's system bash 3.2.57 — no
+# associative arrays, no `${var,,}`, no `inherit_errexit`), curl, sha256sum (or shasum), sed,
+# grep, awk, tr, mktemp, head; git when BASE_REF set or a *_COMMIT tool is refreshed. Dropping
+# `inherit_errexit` (bash 4.4+) for 3.2 portability is compensated everywhere a `$(...)` could
+# otherwise swallow an inner failure: `set -o pipefail` (inherited into command substitutions,
+# unlike errexit) makes the single-pipe fetches fail loudly, and every multi-statement path
+# checks its own exit status explicitly (see fetch_sha's taplo branch, cached_fetch, pinned_*).
 set -euo pipefail
-# Make `set -e` apply INSIDE $(...) too — without this a curl/awk failure inside fetch_sha is
-# swallowed and a partial download could be hashed and pinned.
-shopt -s inherit_errexit
 
 BASE_REF="${BASE_REF:-}"
 if [ -n "$BASE_REF" ] && ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
@@ -44,10 +60,17 @@ fi
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"' EXIT
 
-# The release binaries CI installs by hand. Each pins a SHA256 of its published asset:
-# trivy/osv-scanner/hawkeye/kubeconform publish a checksum file we read; taplo publishes no
-# checksum, so we download the asset and hash it ourselves.
-TOOLS=(TRIVY OSV HAWKEYE TAPLO KUBECONFORM)
+# The asset-bearing release binaries CI installs by hand, each pinned by a SHA256 of its
+# published asset. trivy/osv-scanner/hawkeye/kubeconform/gitleaks publish a checksum file we
+# read; taplo publishes none, so we download the asset and hash it ourselves.
+SHA256_TOOLS=(TRIVY OSV HAWKEYE TAPLO KUBECONFORM GITLEAKS)
+# Asset-less tools installed from a git tag, pinned by the commit id the tag points at (there's
+# no release asset to hash). See the *_COMMIT note in the header.
+COMMIT_TOOLS=(BATS)
+
+lower() { # <hex-ish string> -> lowercased (bash 3.2 has no ${var,,})
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
 
 sha256_of() { # <file> -> bare hex digest
   if command -v sha256sum >/dev/null 2>&1; then
@@ -79,31 +102,73 @@ fetch_sha() { # <TOOL> <version> -> bare hex digest on stdout
     curl -fsSL "${retry[@]}" "https://github.com/yannh/kubeconform/releases/download/v${version}/CHECKSUMS" |
       awk '$2 == "kubeconform-linux-amd64.tar.gz" {print $1}'
     ;;
+  GITLEAKS)
+    curl -fsSL "${retry[@]}" "https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_checksums.txt" |
+      awk -v a="gitleaks_${version}_linux_x64.tar.gz" '$2 == a {print $1}'
+    ;;
   TAPLO)
     # taplo ships no checksum file, so hash the asset (no `v` prefix on taplo tags).
-    # --remove-on-error so a half-written file is never left behind to be hashed.
-    curl -fsSL "${retry[@]}" --remove-on-error \
+    # --remove-on-error so a half-written file is never left behind to be hashed. With
+    # inherit_errexit gone (bash 3.2), curl's failure in this multi-statement branch would
+    # otherwise fall through to sha256_of, so check it explicitly and fail loudly here.
+    if ! curl -fsSL "${retry[@]}" --remove-on-error \
       "https://github.com/tamasfe/taplo/releases/download/${version}/taplo-linux-x86_64.gz" \
-      -o "$WORKDIR/taplo.gz"
+      -o "$WORKDIR/taplo.gz"; then
+      echo "ERROR: fetch_sha: taplo ${version} asset download failed" >&2
+      return 1
+    fi
     sha256_of "$WORKDIR/taplo.gz"
     ;;
   *)
-    echo "unknown tool: $tool" >&2
+    echo "unknown sha256 tool: $tool" >&2
     return 1
     ;;
   esac
 }
 
-# Memoize on tool|version so a version that appears in several workflow files is fetched —
-# or, for taplo, downloaded — at most once. Writes into the caller-named variable ($3) so
-# the cache lives in THIS shell (a `$(...)` return would run in a subshell and lose it).
-declare -A SHA_CACHE=()
-cached_sha() { # <TOOL> <version> <outvar>
-  local key="$1|$2"
-  if [ -z "${SHA_CACHE[$key]+set}" ]; then
-    SHA_CACHE[$key]="$(fetch_sha "$1" "$2")"
-  fi
-  printf -v "$3" '%s' "${SHA_CACHE[$key]}"
+fetch_commit() { # <TOOL> <version> -> bare hex commit id on stdout
+  local tool="$1" version="$2" url
+  case "$tool" in
+  BATS) url="https://github.com/bats-core/bats-core" ;;
+  *)
+    echo "unknown commit tool: $tool" >&2
+    return 1
+    ;;
+  esac
+  # Resolve the release tag to the commit it points at, no local clone. `^{}` dereferences an
+  # annotated tag to its underlying commit; a lightweight tag has no `^{}` row, so fall back to
+  # the plain tag row (already the commit). pipefail (inherited into this `$(...)`) makes a
+  # ls-remote failure abort loudly; a nonexistent tag yields no rows → empty → the caller's
+  # hex-format check rejects it.
+  git ls-remote "$url" "refs/tags/v${version}^{}" "refs/tags/v${version}" |
+    awk -v tag="refs/tags/v${version}" -F'\t' '
+      $2 == tag "^{}" { deref = $1 }
+      $2 == tag       { plain = $1 }
+      END { if (deref != "") print deref; else if (plain != "") print plain }'
+}
+
+# Memoize on class|tool|version so a version that appears in several workflow files is fetched —
+# or, for taplo, downloaded — at most once. bash 3.2 has no associative arrays, so the cache is
+# two parallel indexed arrays scanned linearly (the tool set is tiny). Writes into the
+# caller-named variable ($4) so the cache lives in THIS shell (a `$(...)` return would run in a
+# subshell and lose it).
+PIN_CACHE_KEYS=()
+PIN_CACHE_VALS=()
+cached_fetch() { # <fetch_fn> <TOOL> <version> <outvar>
+  local key="$1|$2|$3" i
+  for i in "${!PIN_CACHE_KEYS[@]}"; do
+    if [ "${PIN_CACHE_KEYS[$i]}" = "$key" ]; then
+      printf -v "$4" '%s' "${PIN_CACHE_VALS[$i]}"
+      return 0
+    fi
+  done
+  local val
+  # A `$(...)` assignment: under set -e a non-zero fetch (curl/ls-remote failure surfaced via
+  # pipefail or an explicit return 1) aborts here loudly instead of caching a partial value.
+  val="$("$1" "$2" "$3")"
+  PIN_CACHE_KEYS+=("$key")
+  PIN_CACHE_VALS+=("$val")
+  printf -v "$4" '%s' "$val"
 }
 
 # Shared tail for pinned_value()/pinned_value_at_base(): extract the quoted value of an
@@ -123,10 +188,12 @@ _extract_pinned_value() { # <VAR> <caller> <location> -> value or empty (reads s
 
 pinned_value() { # <VAR> <file> -> value or empty
   # Fail loudly on a bad path instead of masking it as "no pin found": the guard below
-  # catches a missing file up front; reading it via `cat` under `set -e` catches any other
-  # read failure (e.g. a file that exists but isn't readable) by aborting the assignment.
-  # _extract_pinned_value() separately guards grep's own exit code against the piped
-  # content (conflating "no match" — the intended empty-return case — with a real read
+  # catches a missing file up front; the explicit exit-status check on `cat` catches any other
+  # read failure (e.g. a file that exists but isn't readable) with a labeled `pinned_value:`
+  # error, rather than bash's bare `set -e` aborting the assignment with only cat's raw OS
+  # message ("cat: <file>: Permission denied") and no context — matching every other failure
+  # mode in this file. _extract_pinned_value() separately guards grep's own exit code against
+  # the piped content (conflating "no match" — the intended empty-return case — with a real read
   # error would be the same class of bug this whole file exists to avoid).
   [ -f "$2" ] || {
     echo "ERROR: pinned_value: no such file: $2" >&2
@@ -136,10 +203,23 @@ pinned_value() { # <VAR> <file> -> value or empty
   # passed as an argument — shellcheck's SC2094 (read-and-write-same-file) fires on that
   # syntactic shape even though nothing here is written, only read.
   local content
-  content="$(cat "$2")"
+  if ! content="$(cat "$2")"; then
+    echo "ERROR: pinned_value: read failed: $2" >&2
+    exit 1
+  fi
   printf '%s' "$content" | _extract_pinned_value "$1" pinned_value "$2"
 }
 pinned_value_at_base() { # <VAR> <file> <baseref> -> value at base or empty
+  # Enforce the baseref-resolves-to-a-commit invariant HERE, not only at the top-level BASE_REF
+  # gate, so the function's own "fail loudly on anything but a legitimately-absent path"
+  # guarantee holds regardless of caller. Otherwise an unresolvable ref ($3 a stale/GC'd SHA,
+  # a typo, a shallow clone missing the commit) makes `git cat-file -e $3:$2` emit the SAME
+  # "exists on disk, but not in <ref>" text as a genuinely-absent path — collapsing an
+  # unresolvable ref into a silent empty return instead of the loud failure below.
+  git rev-parse --verify --quiet "$3^{commit}" >/dev/null 2>&1 || {
+    echo "ERROR: pinned_value_at_base: baseref '$3' does not resolve to a commit" >&2
+    exit 1
+  }
   # A path absent at BASE_REF (introduced since) is the one legitimate empty case here.
   # `git cat-file -e`'s exit code alone can't distinguish it from a genuine read error
   # (corrupted object, partial-clone missing blob): a missing path exits 128 with a "does
@@ -171,6 +251,95 @@ pinned_value_at_base() { # <VAR> <file> <baseref> -> value at base or empty
   printf '%s\n' "$blob" | _extract_pinned_value "$1" pinned_value_at_base "$3:$2"
 }
 
+tool_versions_at_base() { # <TOOL> <baseref> -> EVERY version the tool is pinned at at base (one/line)
+  # The tamper gate's continuity check, keyed on TOOL IDENTITY rather than a fixed file path:
+  # find where ${tool}_VERSION lives at BASE_REF across ALL workflow files, so a pin that moved
+  # between files since BASE_REF is still matched to its history. Without this, `git mv old.yml
+  # new.yml` (or a copier update renaming a generated workflow) makes the pin look brand-new and
+  # silently bypasses the same-version/changed-hash tamper check (issue #211).
+  # Emits EVERY base version for the tool (not just the first file's), so the caller can test
+  # whether the CURRENT version is AMONG them — a tool pinned at DIFFERENT versions in two files
+  # at base must not let the first-listed version stand in for the file actually being checked.
+  local tool="$1" baseref="$2" files rc f val
+  # `git grep -l <pattern> <ref> -- <pathspec>` lists "<ref>:<path>" for each matching file at
+  # the ref. Exit 1 == no matches (a legitimately never-pinned tool → empty), exit >1 == a real
+  # error (mirror _extract_pinned_value's grep-exit handling and fail loudly).
+  files="$(git grep -lE "^[[:space:]]*${tool}_VERSION: \"" "$baseref" -- \
+    '.github/workflows/*.yml' '.github/workflows/*.yaml')" && rc=0 || rc=$?
+  if [ "$rc" -gt 1 ]; then
+    echo "ERROR: tool_versions_at_base: git grep failed (exit $rc) for ${tool} at ${baseref}" >&2
+    exit 1
+  fi
+  [ -n "$files" ] || return 0
+  # Heredoc (not a pipe) so the loop runs in THIS shell and an `exit` inside pinned_value_at_base
+  # propagates instead of dying in a subshell.
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    f="${f#"${baseref}":}" # strip the "<ref>:" prefix git grep -l prepends
+    val="$(pinned_value_at_base "${tool}_VERSION" "$f" "$baseref")"
+    [ -n "$val" ] && printf '%s\n' "$val"
+  done <<EOF
+$files
+EOF
+}
+
+changed=0
+processed=0
+
+# Refresh one tool's pin in one file. Shared by both pin classes — only the pin var suffix, the
+# fetch function, and the accepted value format differ.
+refresh_pin() { # <file> <TOOL> <suffix> <fetch_fn> <valid-regex> <label>
+  local file="$1" tool="$2" suffix="$3" fetch_fn="$4" valid_re="$5" label="$6"
+  local version old_pin new_pin base_versions tmp
+  # NOTE: reads the first *_VERSION but rewrites every *_<suffix> (sed /g). That is correct
+  # because a tool pinned more than once in a file shares one version; do not pin the same
+  # tool to two different versions in one file.
+  version="$(pinned_value "${tool}_VERSION" "$file")"
+  [ -n "$version" ] || return 0
+  old_pin="$(pinned_value "${tool}_${suffix}" "$file")"
+  [ -n "$old_pin" ] || return 0
+  old_pin="$(lower "$old_pin")"
+  processed=$((processed + 1))
+
+  new_pin=""
+  cached_fetch "$fetch_fn" "$tool" "$version" new_pin
+  new_pin="$(lower "$new_pin")" # normalize: compare/store lowercase even if upstream emits uppercase hex
+  if [[ ! "$new_pin" =~ $valid_re ]]; then
+    echo "ERROR: ${tool} ${version}: upstream did not yield a ${label} (got '${new_pin}')" >&2
+    exit 1
+  fi
+
+  if [ -n "$BASE_REF" ] && [ "$new_pin" != "$old_pin" ]; then
+    # Tamper iff this EXACT version was pinned somewhere at BASE_REF (same version + changed pin
+    # = a swapped asset/tag). Captured to a variable first (not piped into grep) so a git-grep
+    # error inside the function still aborts loudly under set -e; membership (`grep -qxF`), not
+    # equality against one arbitrarily-chosen version, so a tool pinned at different versions in
+    # two files at base can't let a same-version tamper in the OTHER file slip through.
+    base_versions="$(tool_versions_at_base "$tool" "$BASE_REF")"
+    if printf '%s\n' "$base_versions" | grep -qxF "$version"; then
+      echo "TAMPER ALERT: ${tool} ${version} in ${file}: pinned ${label} ${old_pin} != upstream" >&2
+      echo "  ${new_pin}, but the version is unchanged vs ${BASE_REF}. Refusing to auto-update —" >&2
+      echo "  investigate the upstream release (a fixed tag's asset/commit should never change)." >&2
+      exit 1
+    fi
+  fi
+
+  if [ "$new_pin" != "$old_pin" ]; then
+    tmp="$(mktemp)"
+    sed -E "s|(${tool}_${suffix}: \")[0-9a-fA-F]*(\")|\1${new_pin}\2|g" "$file" >"$tmp"
+    if ! grep -q "${tool}_${suffix}: \"${new_pin}\"" "$tmp"; then
+      rm -f "$tmp"
+      echo "ERROR: failed to rewrite ${tool}_${suffix} in ${file}" >&2
+      exit 1
+    fi
+    mv "$tmp" "$file"
+    echo "updated ${file}: ${tool} ${version} -> ${new_pin}"
+    changed=1
+  else
+    echo "ok ${file}: ${tool} ${version} (${new_pin})"
+  fi
+}
+
 if [ "$#" -gt 0 ]; then
   targets=("$@")
 else
@@ -183,57 +352,18 @@ else
   done
 fi
 
-changed=0
-processed=0
 for file in "${targets[@]}"; do
-  for tool in "${TOOLS[@]}"; do
-    # NOTE: reads the first *_VERSION but rewrites every *_SHA256 (sed /g). That is correct
-    # because a tool pinned more than once in a file shares one version; do not pin the same
-    # tool to two different versions in one file.
-    version="$(pinned_value "${tool}_VERSION" "$file")"
-    [ -n "$version" ] || continue
-    old_sha="$(pinned_value "${tool}_SHA256" "$file")"
-    [ -n "$old_sha" ] || continue
-    old_sha="${old_sha,,}"
-    processed=$((processed + 1))
-
-    new_sha=""
-    cached_sha "$tool" "$version" new_sha
-    new_sha="${new_sha,,}" # normalize: compare/store lowercase even if an upstream emits uppercase hex
-    if [[ ! "$new_sha" =~ ^[0-9a-f]{64}$ ]]; then
-      echo "ERROR: ${tool} ${version}: upstream did not yield a SHA256 (got '${new_sha}')" >&2
-      exit 1
-    fi
-
-    if [ -n "$BASE_REF" ] && [ "$new_sha" != "$old_sha" ]; then
-      base_version="$(pinned_value_at_base "${tool}_VERSION" "$file" "$BASE_REF")"
-      if [ -n "$base_version" ] && [ "$base_version" = "$version" ]; then
-        echo "TAMPER ALERT: ${tool} ${version} in ${file}: pinned SHA ${old_sha} != upstream" >&2
-        echo "  ${new_sha}, but the version is unchanged vs ${BASE_REF}. Refusing to auto-update —" >&2
-        echo "  investigate the upstream release (a fixed tag's asset should never change)." >&2
-        exit 1
-      fi
-    fi
-
-    if [ "$new_sha" != "$old_sha" ]; then
-      tmp="$(mktemp)"
-      sed -E "s|(${tool}_SHA256: \")[0-9a-fA-F]*(\")|\1${new_sha}\2|g" "$file" >"$tmp"
-      if ! grep -q "${tool}_SHA256: \"${new_sha}\"" "$tmp"; then
-        rm -f "$tmp"
-        echo "ERROR: failed to rewrite ${tool}_SHA256 in ${file}" >&2
-        exit 1
-      fi
-      mv "$tmp" "$file"
-      echo "updated ${file}: ${tool} ${version} -> ${new_sha}"
-      changed=1
-    else
-      echo "ok ${file}: ${tool} ${version} (${new_sha})"
-    fi
+  for tool in "${SHA256_TOOLS[@]}"; do
+    refresh_pin "$file" "$tool" SHA256 fetch_sha '^[0-9a-f]{64}$' SHA256
+  done
+  for tool in "${COMMIT_TOOLS[@]}"; do
+    # git commit ids are 40-hex (sha1) or 64-hex (sha256, once a repo migrates).
+    refresh_pin "$file" "$tool" COMMIT fetch_commit '^([0-9a-f]{40}|[0-9a-f]{64})$' "commit id"
   done
 done
 
 if [ "$processed" -eq 0 ]; then
-  echo "ERROR: no *_SHA256 pins found in: ${targets[*]} (regex drift, or wrong working dir?)" >&2
+  echo "ERROR: no *_SHA256 / *_COMMIT pins found in: ${targets[*]} (regex drift, or wrong working dir?)" >&2
   exit 1
 fi
 if [ "$changed" -eq 0 ]; then


### PR DESCRIPTION
## What

Advances [issue #30](https://github.com/nivintw/ddns/issues/30) (build first MkDocs Material docs site + enable Pages) by pulling the **copier-everything v1.12.0** template render into the repo. The docs-site scaffolding (mkdocs.yml, docs/ content, docs.yml caller workflow) already landed on `main` in prior work; this PR brings the repo current with v1.12.0 and keeps the docs infra in sync with the template.

### v1.12.0 brings
- Guard-hooks + twin-sync enforcement toolkit (`.claude/hooks/`), licensed via REUSE.toml.
- Generic **multi-package release-please model** in `main.yml` (this repo is the N=1 case; `release_model: single` recorded in the answers).
- `scripts/check_copier_src_path.py` commit gate (fails if `_src_path` is a local path).
- PyPI upload guard + generic link excludes in `.config/lychee.toml`.

### Conflict resolutions (all toward template convergence)
- **main.yml** — took the template's canonical two-phase stranded-Release-PR closer; `main`'s local fix for the same GraphQL node-budget bug (`09ffbdf`) is superseded by the more robust upstream port and dropped.
- **mkdocs.yml** — dropped the local asciinema-player note now that the template no longer wires those assets unconditionally (identical outcome, divergence gone).
- **pyproject.toml** — adopted the new `scripts/**` ruff ignore; kept this repo's deliberate `tests/**` rule.
- **docs/includes/install.md** — kept the repo-authored fragment over the template's placeholder boilerplate.

## Verification
- Full `uvx prek@0.4.8 run --all-files` gate: **green** (ruff, ty, REUSE/hawkeye, zizmor, actionlint, gitleaks, taplo, etc.).
- `uv run pytest`: **108 passed**, 95.67% coverage.
- `mkdocs build`: clean locally; the social-card imaging deps (cairosvg/PIL) resolve only on the Linux CI build, as documented in `mkdocs.yml`.

## Remaining for issue #30 (out of this repo's tree)
- Declaring `pages: {enabled: true, build_type: workflow}` lives in **`config/ddns.yml` in nivintw/repo-management** (consumed by `PagesManager`), not in this repo — a separate cross-repo change.
- Live-site verification (nav, search, theme toggle, mobile) follows once Pages is enabled there.

Closes #30